### PR TITLE
39 heroku deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,24 +13,25 @@
     "build-watch": "check-node-version --node '>= 6.7.0' && webpack -w",
     "start[dev]": "check-node-version --node '>= 6.7.0' && nodemon server/start.js",
     "start[prod]": "check-node-version --node '>= 6.7.0' && node server/start.js",
-    "start": "check-node-version --node '>= 6.7.0' && bin/conditionalStart.sh",
-    "seed": "node db/seed.js"
+    "start": "check-node-version --node '>= 6.7.0' && npm run start[prod]",
+    "seed": "node db/seed.js",
+    "postinstall": "npm run build && node db/seed.js",
+    "heroku-prebuild": "heroku config:set NPM_CONFIG_PRODUCTION=false"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/queerviolet/bones.git"
+    "url": "git+https://github.com/spmcbride1201/cookie-monsters.git"
   },
   "keywords": [
     "react",
-    "redux",
-    "skeleton"
+    "redux"
   ],
-  "author": "Ashi Krishnan <me@ashi.works>",
+  "author": "Sean McBride, Evan DiGiambattista, and Rachel Bird",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/queerviolet/bones/issues"
+    "url": "https://github.com/spmcbride1201/cookie-monsters/issues"
   },
-  "homepage": "https://github.com/queerviolet/bones#readme",
+  "homepage": "https://github.com/spmcbride1201/cookie-monsters#readme",
   "dependencies": {
     "axios": "^0.15.2",
     "babel-preset-stage-2": "^6.18.0",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "start[prod]": "check-node-version --node '>= 6.7.0' && node server/start.js",
     "start": "check-node-version --node '>= 6.7.0' && npm run start[prod]",
     "seed": "node db/seed.js",
-    "postinstall": "npm run build && node db/seed.js",
-    "heroku-prebuild": "set NPM_CONFIG_PRODUCTION=false"
+    "postinstall": "npm run build && node db/seed.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "check-node-version --node '>= 6.7.0' && npm run start[prod]",
     "seed": "node db/seed.js",
     "postinstall": "npm run build && node db/seed.js",
-    "heroku-prebuild": "heroku config:set NPM_CONFIG_PRODUCTION=false"
+    "heroku-prebuild": "config:set NPM_CONFIG_PRODUCTION=false"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "check-node-version --node '>= 6.7.0' && npm run start[prod]",
     "seed": "node db/seed.js",
     "postinstall": "npm run build && node db/seed.js",
-    "heroku-prebuild": "config:set NPM_CONFIG_PRODUCTION=false"
+    "heroku-prebuild": "set NPM_CONFIG_PRODUCTION=false"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I refactored the package.json to eliminate the dependency on the BASH script and get heroku deployment working properly. I've kept the BASH script in the ./bin directory.

If we want to use nodemon, now we need to run `npm run start[dev]` instead of just `npm start`.

Closes #44 
Closes $39