### PR TITLE
fix: Cart now only clears on logout

### DIFF
--- a/app/reducers/auth.jsx
+++ b/app/reducers/auth.jsx
@@ -13,6 +13,16 @@ export const authenticated = user => ({
   type: AUTHENTICATED, user
 })
 
+// wipeLocalState is an action creator that dispatches an action that the rrot reducer uses as a hook
+// to know when to clear the cart. The idea is that a cart should persist in localStorage until a
+// user logs out of the site. This theoretically could be used with server site persistance of carts for
+// logged in users in the future.
+
+const WIPELOCALSTATE = 'WIPELOCALSTATE'
+export const wipeLocalState = () => ({
+  type: WIPELOCALSTATE
+})
+
 export const login = (username, password) =>
   dispatch =>
     axios.post('/api/auth/local/login',
@@ -31,8 +41,14 @@ export const logout = () =>
   dispatch => {
     console.log('dispatch: ', dispatch)
     axios.post('/api/auth/logout')
-      .then(() => dispatch(whoami()))
-      .catch(() => dispatch(whoami()))
+      .then(() => {
+        dispatch(whoami());
+        dispatch(wipeLocalState());
+      })
+      .catch(() => {
+        dispatch(whoami());
+        dispatch(wipeLocalState());
+      })
   }
 
 export const whoami = () =>

--- a/app/reducers/index.jsx
+++ b/app/reducers/index.jsx
@@ -13,7 +13,7 @@ const appReducer = combineReducers({
 })
 
 const rootReducer = (state, action) => {
-  if (action.type === 'AUTHENTICATED' && action.user === '') {
+  if (action.type === 'WIPELOCALSTATE') {
     localStorage.clear();
     state.cart = [];
     state.users = initialUsersState;


### PR DESCRIPTION
I created a new action type that I use as a hook for the wipeCart behavior. This prevents accidentally clearing of the store and localStorage and ensures this only happens when a user logs out.