### PR TITLE
chore: add ESLint, Prettier, and baseline formatting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules/
+public/

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,34 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 2018,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  },
+  "env": {
+    "browser": true,
+    "node": true,
+    "es6": true
+  },
+  "plugins": ["react"],
+  "extends": ["eslint:recommended", "plugin:react/recommended", "prettier"],
+  "settings": {
+    "react": {
+      "version": "15"
+    }
+  },
+  "rules": {
+    "no-console": "warn",
+    "no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
+    "react/prop-types": "off"
+  },
+  "overrides": [
+    {
+      "files": ["**/*.test.js", "**/*.test.jsx"],
+      "env": {
+        "mocha": true
+      }
+    }
+  ]
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Normalize line endings to LF in the repo; check out as-is on all platforms.
+* text=auto eol=lf
+*.cmd text eol=crlf
+*.bat text eol=crlf

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 80,
+  "arrowParens": "avoid"
+}

--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -1,11 +1,11 @@
-import React, { Component } from 'react';
-import Footer from './Footer';
-import NavContainer from '../containers/NavContainer';
+import React, { Component } from 'react'
+import Footer from './Footer'
+import NavContainer from '../containers/NavContainer'
 
 export default ({ children }) => (
   <div id="main" className="container-fluid">
     <NavContainer />
-    { children }
+    {children}
     <Footer />
   </div>
-);
+)

--- a/app/components/Cart.jsx
+++ b/app/components/Cart.jsx
@@ -1,27 +1,32 @@
-'use strict';
+'use strict'
 
-import React, { Component } from 'react';
-import Cart from './Cart';
-import { Link } from 'react-router';
+import React, { Component } from 'react'
+import Cart from './Cart'
+import { Link } from 'react-router'
 
-export default (props) => {
-  let numOfItems = 0;
-  let total = 0;
-  props.cart.forEach((cartLineItem) => {
-    numOfItems += cartLineItem.quantity;
-    total += (cartLineItem.product.price * cartLineItem.quantity);
+export default props => {
+  let numOfItems = 0
+  let total = 0
+  props.cart.forEach(cartLineItem => {
+    numOfItems += cartLineItem.quantity
+    total += cartLineItem.product.price * cartLineItem.quantity
   })
   return (
     <div className="pull-right">
       <p id="cartPreviewText">
         <i id="cartPreviewIcon" className="fa fa-shopping-cart"></i>
-        <span> {numOfItems}</span> items totaling <span>${(total).toFixed(2)} </span>
-        {
-          window.location.pathname === "/viewcart" ?
-          <Link className="btn btn-warning btn-sm" to="/products">Buy more</Link> :
-          <Link className="btn btn-success btn-sm" to="/viewcart">View Cart</Link>
-        }
+        <span> {numOfItems}</span> items totaling{' '}
+        <span>${total.toFixed(2)} </span>
+        {window.location.pathname === '/viewcart' ? (
+          <Link className="btn btn-warning btn-sm" to="/products">
+            Buy more
+          </Link>
+        ) : (
+          <Link className="btn btn-success btn-sm" to="/viewcart">
+            View Cart
+          </Link>
+        )}
       </p>
     </div>
   )
-};
+}

--- a/app/components/CartEmpty.jsx
+++ b/app/components/CartEmpty.jsx
@@ -1,18 +1,24 @@
-import React, { Component } from 'react';
+import React, { Component } from 'react'
 
-export default (props) => {
-	return (
-		<div id="cart-empty-container" className="container">
-			<div className="jumbotron center">
-			  <h1>Uh oh!...</h1>
-			  <br/>
-			  <p>You have no cookies in your cart. Add some cookies, ya idiot!</p>
-			  	<div className="text-center">
-			  	<p>
-			  		<a href="/products" className="btn btn-primary btn-lg" role="button">Go!</a>
-			  	</p>
-			  	</div>
-			</div>
-		</div>
-	);
-};
+export default props => {
+  return (
+    <div id="cart-empty-container" className="container">
+      <div className="jumbotron center">
+        <h1>Uh oh!...</h1>
+        <br />
+        <p>You have no cookies in your cart. Add some cookies, ya idiot!</p>
+        <div className="text-center">
+          <p>
+            <a
+              href="/products"
+              className="btn btn-primary btn-lg"
+              role="button"
+            >
+              Go!
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/components/CartLineItem.jsx
+++ b/app/components/CartLineItem.jsx
@@ -1,39 +1,46 @@
-'use strict';
+'use strict'
 
-import React from 'react';
-import { Link } from 'react-router';
+import React from 'react'
+import { Link } from 'react-router'
 
-export default (props) => {
-	return (
-		<div id="cart-line-item" className="container">
-			<div className="panel panel-success">
-			  <div className="panel-heading">
-				  <div className="row">
-				  	<div className="col-sm-10 col-xs-9">
-				    	<h3 className="panel-title text-left">{ props.name }</h3>
-				    </div>
-				    <div className="col-sm-2 col-xs-3 text-right">
-				    	<button id="remove-from-cart" className="btn btn-sm btn-danger">Remove</button>
-				    </div>
-				  </div>
-			  </div>
-			  <div className="panel-body">
-			    <div className="media">
-					  <div className="media-left">
-					  <div className="thumbContainer">
-					    <Link to="/reviews"> <img className="thumbImg" src={ props.photo } alt={ props.name }/>
-					    </Link>
-					  </div>
-					  </div>
-					  <div className="media-body">
-					    <p>{ props.description }</p>
-					    <p>Qty: { props.quantity }</p>
-					    <p>Price: ${ (props.price * props.quantity).toFixed(2) }</p>
-					  </div>
-					</div>
-			  </div>
-			</div>
-		</div>
-
-	);
-};
+export default props => {
+  return (
+    <div id="cart-line-item" className="container">
+      <div className="panel panel-success">
+        <div className="panel-heading">
+          <div className="row">
+            <div className="col-sm-10 col-xs-9">
+              <h3 className="panel-title text-left">{props.name}</h3>
+            </div>
+            <div className="col-sm-2 col-xs-3 text-right">
+              <button id="remove-from-cart" className="btn btn-sm btn-danger">
+                Remove
+              </button>
+            </div>
+          </div>
+        </div>
+        <div className="panel-body">
+          <div className="media">
+            <div className="media-left">
+              <div className="thumbContainer">
+                <Link to="/reviews">
+                  {' '}
+                  <img
+                    className="thumbImg"
+                    src={props.photo}
+                    alt={props.name}
+                  />
+                </Link>
+              </div>
+            </div>
+            <div className="media-body">
+              <p>{props.description}</p>
+              <p>Qty: {props.quantity}</p>
+              <p>Price: ${(props.price * props.quantity).toFixed(2)}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/components/CartView.js
+++ b/app/components/CartView.js
@@ -1,30 +1,47 @@
-import React from 'react';
-import Hero from './Hero';
-import CartEmpty from './CartEmpty';
-import CartLineItem from './CartLineItem';
+import React from 'react'
+import Hero from './Hero'
+import CartEmpty from './CartEmpty'
+import CartLineItem from './CartLineItem'
 
-export default (props) => {
+export default props => {
   return (
     <div id="cart-view" className="container">
       <Hero />
-      <br/>
+      <br />
       <div className="row">
         <div className="col-sm-6 col-xs-12">
-          { props.cart < 1 ? <CartEmpty /> :  props.cart.map(item => <CartLineItem key={ item.product.id }
-            name={ item.product.name }
-            quantity={ item.quantity }
-            photo={ item.product.photo }
-            description={ item.product.description }
-            price={ item.product.price } />) }
+          {props.cart < 1 ? (
+            <CartEmpty />
+          ) : (
+            props.cart.map(item => (
+              <CartLineItem
+                key={item.product.id}
+                name={item.product.name}
+                quantity={item.quantity}
+                photo={item.product.photo}
+                description={item.product.description}
+                price={item.product.price}
+              />
+            ))
+          )}
         </div>
       </div>
-      { props.cart.length > 0 ? <div className="text-center"><button onClick={
-        (evt) => {
-          evt.preventDefault();
-          props.submitOrder(props.cart);
-        }
-      } className="btn btn-success btn-lg">Checkout</button></div> : '' }
-      <br/>
+      {props.cart.length > 0 ? (
+        <div className="text-center">
+          <button
+            onClick={evt => {
+              evt.preventDefault()
+              props.submitOrder(props.cart)
+            }}
+            className="btn btn-success btn-lg"
+          >
+            Checkout
+          </button>
+        </div>
+      ) : (
+        ''
+      )}
+      <br />
     </div>
-  );
-};
+  )
+}

--- a/app/components/Footer.jsx
+++ b/app/components/Footer.jsx
@@ -1,12 +1,35 @@
-'use strict';
+'use strict'
 
-import React, { Component } from 'react';
-import {Link} from 'react-router';
+import React, { Component } from 'react'
+import { Link } from 'react-router'
 
 export default () => (
   <div className="footer">
-      <div className="container">
-        <p className="text-muted">Created by <Link to="http://spmcb.com/" target="_blank" rel="noopener noreferrer">Sean</Link>, <Link to="https://myspace.com/evandigiambattista" target="_blank" rel="noopener noreferrer">Evan</Link>, and <Link to="http://rachelbird.com/" target="_blank" rel="noopener noreferrer">Rachel</Link>: the Cookie Monsters of Fullstack Academy <i className="fa fa-graduation-cap"></i></p>
-      </div>
+    <div className="container">
+      <p className="text-muted">
+        Created by{' '}
+        <Link to="http://spmcb.com/" target="_blank" rel="noopener noreferrer">
+          Sean
+        </Link>
+        ,{' '}
+        <Link
+          to="https://myspace.com/evandigiambattista"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Evan
+        </Link>
+        , and{' '}
+        <Link
+          to="http://rachelbird.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Rachel
+        </Link>
+        : the Cookie Monsters of Fullstack Academy{' '}
+        <i className="fa fa-graduation-cap"></i>
+      </p>
     </div>
-);
+  </div>
+)

--- a/app/components/Hero.jsx
+++ b/app/components/Hero.jsx
@@ -1,18 +1,18 @@
-import React from 'react';
-import Cart from '../containers/CartContainer';
+import React from 'react'
+import Cart from '../containers/CartContainer'
 
 export default function (props) {
   return (
     <div id="headerRow" className="row">
       <div className="col-sm-6 col-xs-12">
-        <img className="cookieMonsterImg" src='/images/cookie-monster.jpg' />
+        <img className="cookieMonsterImg" src="/images/cookie-monster.jpg" />
         <h1>Cookie Monsters</h1>
         <h3 className="subtitle">Home of the world's greatest cookies</h3>
       </div>
       <div id="cartRow" className="col-sm-6 col-xs-12">
         <Cart />
       </div>
-      <br/>
+      <br />
     </div>
   )
 }

--- a/app/components/Login.jsx
+++ b/app/components/Login.jsx
@@ -1,18 +1,29 @@
 import React from 'react'
 
 export default function (props) {
-  let login = props.login;
+  let login = props.login
   return (
-  <div className="container">
-    <h1 className="display-4">Login</h1>
-    <form onSubmit={evt => {
-      evt.preventDefault()
-      login(evt.target.username.value, evt.target.password.value)
-    } }>
-      <input className="form-control auth-field" name="username" placeholder="Username" />
-      <input className="form-control auth-field" name="password" type="password"  placeholder="Password" />
-      <input className="btn btn-primary" type="submit" value="Login" />
-    </form>
-  </div>
-)}
-
+    <div className="container">
+      <h1 className="display-4">Login</h1>
+      <form
+        onSubmit={evt => {
+          evt.preventDefault()
+          login(evt.target.username.value, evt.target.password.value)
+        }}
+      >
+        <input
+          className="form-control auth-field"
+          name="username"
+          placeholder="Username"
+        />
+        <input
+          className="form-control auth-field"
+          name="password"
+          type="password"
+          placeholder="Password"
+        />
+        <input className="btn btn-primary" type="submit" value="Login" />
+      </form>
+    </div>
+  )
+}

--- a/app/components/MyOrders.jsx
+++ b/app/components/MyOrders.jsx
@@ -1,30 +1,42 @@
-import React, { Component } from 'react';
-import { Link } from 'react-router';
-import MyOrdersItem from './MyOrdersItem';
+import React, { Component } from 'react'
+import { Link } from 'react-router'
+import MyOrdersItem from './MyOrdersItem'
 
-export default (props) => {
+export default props => {
   return (
     <div className="container">
       <h1 className="display-4">My Orders</h1>
       {/* Handle if no orders */}
       {props.orders.length === 0 ? (
         <div className="container">
-        <div id="no-orders" className="jumbotron center">
-          <div>
-            <p>
-              You haven't placed any orders yet. <br />
-              Get some cookies!
-            </p>
+          <div id="no-orders" className="jumbotron center">
+            <div>
+              <p>
+                You haven't placed any orders yet. <br />
+                Get some cookies!
+              </p>
+            </div>
+            <div>
+              <Link to="/products" className="btn btn-primary btn-lg">
+                Go!
+              </Link>
+            </div>
           </div>
-          <div><Link to="/products" className="btn btn-primary btn-lg">Go!</Link></div>
         </div>
-      </div>
-        ) : ''}
+      ) : (
+        ''
+      )}
       <div>
         {/* Loop over orders */}
         {/* Ideally would sort these with most recent order first */}
-        {props.orders.map(order => <MyOrdersItem key={order.id} order={order} selectOrder={props.selectOrder}/>)}
+        {props.orders.map(order => (
+          <MyOrdersItem
+            key={order.id}
+            order={order}
+            selectOrder={props.selectOrder}
+          />
+        ))}
       </div>
     </div>
   )
-};
+}

--- a/app/components/MyOrdersItem.jsx
+++ b/app/components/MyOrdersItem.jsx
@@ -1,26 +1,32 @@
-'use strict';
+'use strict'
 
-import React from 'react';
-import {Link} from 'react-router';
+import React from 'react'
+import { Link } from 'react-router'
 
-export default (props) => {
+export default props => {
   return (
     <div className="panel panel-success">
       <div className="panel-heading">
         {/* Link to order detail */}
-        <Link onClick={(evt) => props.selectOrder(props.order)} to="/order"><h3 className="panel-title">Order ID: {props.order.id}</h3></Link>
+        <Link onClick={evt => props.selectOrder(props.order)} to="/order">
+          <h3 className="panel-title">Order ID: {props.order.id}</h3>
+        </Link>
       </div>
       <div className="panel-body">
         <div className="media">
           <div className="media-body">
             {/* Shipping information */}
             <p>Order created {props.order.created_at}</p>
-            <p>Shipped by {props.order.shippingCarrier || "Omri in a beige Dodge Van"} on January 15, 2017</p>
+            <p>
+              Shipped by{' '}
+              {props.order.shippingCarrier || 'Omri in a beige Dodge Van'} on
+              January 15, 2017
+            </p>
             {/* Order total */}
             <p>Total: ${props.order.total}</p>
           </div>
         </div>
       </div>
     </div>
-  );
-};
+  )
+}

--- a/app/components/Nav.jsx
+++ b/app/components/Nav.jsx
@@ -1,57 +1,90 @@
-'use strict';
+'use strict'
 
-import React, { Component } from 'react';
-import { Link } from 'react-router';
+import React, { Component } from 'react'
+import { Link } from 'react-router'
 
-export default (props) => (
-    <nav className="navbar navbar-default">
-      <div className="container-fluid">
-        {/* Brand and toggle get grouped for better mobile display */}
-        <div className="navbar-header">
-          <button type="button" className="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
-            <span className="sr-only">Toggle navigation</span>
-            <span className="icon-bar" />
-            <span className="icon-bar" />
-            <span className="icon-bar" />
-          </button>
-          <a className="navbar-brand" href="/products">
-            <img id="brand" alt="Brand" src="/images/brand.png" />
-            <span id="brand-title">Cookie Monsters</span>
-          </a>
-        </div>
-        {/* Collect the nav links, forms, and other content for toggling */}
-        <div className="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-            {/* handles if user is logged in or not */}
-            {/* have to put ul's inside ternary for styling purposes */}
-            {props.auth ? (
-              <ul className="nav navbar-nav navbar-right">
-                <li>
-                  {/* TODO: this link doesn't work correctly yet */}
-                  <p className="navbar-text">Hello, <a onClick={(evt)=>{
-                      evt.preventDefault();
-                      props.selectUser(props.auth);
-                    }}>{props.auth.name}</a>!
-                  </p>
-                </li>
-                <li><Link to="/myorders">My Orders</Link></li>
-                {props.auth.isAdmin ? (<li><Link to="/users">Users</Link></li>) : ''}
-                <li>
-                  <a onClick={evt => {
+export default props => (
+  <nav className="navbar navbar-default">
+    <div className="container-fluid">
+      {/* Brand and toggle get grouped for better mobile display */}
+      <div className="navbar-header">
+        <button
+          type="button"
+          className="navbar-toggle collapsed"
+          data-toggle="collapse"
+          data-target="#bs-example-navbar-collapse-1"
+          aria-expanded="false"
+        >
+          <span className="sr-only">Toggle navigation</span>
+          <span className="icon-bar" />
+          <span className="icon-bar" />
+          <span className="icon-bar" />
+        </button>
+        <a className="navbar-brand" href="/products">
+          <img id="brand" alt="Brand" src="/images/brand.png" />
+          <span id="brand-title">Cookie Monsters</span>
+        </a>
+      </div>
+      {/* Collect the nav links, forms, and other content for toggling */}
+      <div
+        className="collapse navbar-collapse"
+        id="bs-example-navbar-collapse-1"
+      >
+        {/* handles if user is logged in or not */}
+        {/* have to put ul's inside ternary for styling purposes */}
+        {props.auth ? (
+          <ul className="nav navbar-nav navbar-right">
+            <li>
+              {/* TODO: this link doesn't work correctly yet */}
+              <p className="navbar-text">
+                Hello,{' '}
+                <a
+                  onClick={evt => {
+                    evt.preventDefault()
+                    props.selectUser(props.auth)
+                  }}
+                >
+                  {props.auth.name}
+                </a>
+                !
+              </p>
+            </li>
+            <li>
+              <Link to="/myorders">My Orders</Link>
+            </li>
+            {props.auth.isAdmin ? (
+              <li>
+                <Link to="/users">Users</Link>
+              </li>
+            ) : (
+              ''
+            )}
+            <li>
+              <a
+                onClick={evt => {
                   evt.preventDefault()
                   props.logout()
-                  } }>Logout</a>
-                </li>
-              </ul>
-            ) : (
-                <div>
-                  <ul className="nav navbar-nav navbar-right">
-                    <li><Link to="/signup">Sign Up</Link></li>
-                    <li><Link to="/login">Login</Link></li>
-                  </ul>
-                </div>
-              )
-            }
-        </div>{/* /.navbar-collapse */}
-      </div>{/* /.container-fluid */}
-    </nav>
-  );
+                }}
+              >
+                Logout
+              </a>
+            </li>
+          </ul>
+        ) : (
+          <div>
+            <ul className="nav navbar-nav navbar-right">
+              <li>
+                <Link to="/signup">Sign Up</Link>
+              </li>
+              <li>
+                <Link to="/login">Login</Link>
+              </li>
+            </ul>
+          </div>
+        )}
+      </div>
+      {/* /.navbar-collapse */}
+    </div>
+    {/* /.container-fluid */}
+  </nav>
+)

--- a/app/components/Order.jsx
+++ b/app/components/Order.jsx
@@ -1,13 +1,13 @@
-'use strict';
+'use strict'
 
-import React, { Component } from 'react';
-import { Link } from 'react-router';
+import React, { Component } from 'react'
+import { Link } from 'react-router'
 
-export default (props) => {
+export default props => {
   return (
     <div className="container">
       <div>
-        <img className="cookieMonsterImg" src='/images/cookie-monster.jpg' />
+        <img className="cookieMonsterImg" src="/images/cookie-monster.jpg" />
         <h1>Cookie Monsters</h1>
         <h3 className="subtitle">Home of the world's greatest cookies</h3>
       </div>
@@ -24,7 +24,9 @@ export default (props) => {
           <tfoot>
             <tr>
               <td></td>
-              <td className="pull-right orderTableFooterTitles">Flat Shipping Rate</td>
+              <td className="pull-right orderTableFooterTitles">
+                Flat Shipping Rate
+              </td>
               <td>${props.order.shippingRate}</td>
             </tr>
             <tr>
@@ -44,15 +46,16 @@ export default (props) => {
                 <td>{product.orderLineItems.quantity}</td>
                 <td>{product.name}</td>
                 <td>$ {product.orderLineItems.subtotal}</td>
-              </tr>)
-            )}
+              </tr>
+            ))}
           </tbody>
         </table>
         {/* This should appear after order is submitted */}
         <div className="lead">
-          Cookies shipped by <span id="shippingCarrier">{props.order.shippingCarrier}</span>.
-      </div>
+          Cookies shipped by{' '}
+          <span id="shippingCarrier">{props.order.shippingCarrier}</span>.
+        </div>
       </div>
     </div>
   )
-};
+}

--- a/app/components/Product.jsx
+++ b/app/components/Product.jsx
@@ -1,7 +1,7 @@
-'use strict';
+'use strict'
 
-import React, { Component } from 'react';
-import { Link } from 'react-router';
+import React, { Component } from 'react'
+import { Link } from 'react-router'
 
 export default ({ cookie, plusItemzToCart }) => (
   <div className="col-xs-18 col-sm-6 col-md-3">
@@ -10,23 +10,45 @@ export default ({ cookie, plusItemzToCart }) => (
         <img className="cookieImage" src={cookie.photo} />
       </div>
       <div className="caption">
-    {/* Handles case of Seinfeld's race relations cookie discussion */}
-        <h4>{cookie.name === "Black & White Cookie" ? (
-           <a href="https://www.youtube.com/watch?v=IlLPAIrmqvE">{cookie.name}</a>
-           ) : (cookie.name) }</h4>
+        {/* Handles case of Seinfeld's race relations cookie discussion */}
+        <h4>
+          {cookie.name === 'Black & White Cookie' ? (
+            <a href="https://www.youtube.com/watch?v=IlLPAIrmqvE">
+              {cookie.name}
+            </a>
+          ) : (
+            cookie.name
+          )}
+        </h4>
         <p>{cookie.description}</p>
-        <p className="cookieCategory">{cookie.categories.map(category => category).join(', ')}</p>
-        <p><Link to="/reviews">Reviews</Link></p>
-        <p><span id="quantityText">Quantity: </span>
-          <input id={`number_of_cookie_${cookie.id}`} className="form-control quantity" name="quantity" defaultValue="1" />
-          <a className="btn btn-info btn-sm" role="button" onClick={(evt) => {
-            evt.preventDefault();
-            let quantity = parseInt($(`#number_of_cookie_${cookie.id}`).val());
-            plusItemzToCart(cookie, quantity);
-            alert(`Added ${quantity} ${cookie.name} to cart`);
-          } }>Add to cart</a>
+        <p className="cookieCategory">
+          {cookie.categories.map(category => category).join(', ')}
+        </p>
+        <p>
+          <Link to="/reviews">Reviews</Link>
+        </p>
+        <p>
+          <span id="quantityText">Quantity: </span>
+          <input
+            id={`number_of_cookie_${cookie.id}`}
+            className="form-control quantity"
+            name="quantity"
+            defaultValue="1"
+          />
+          <a
+            className="btn btn-info btn-sm"
+            role="button"
+            onClick={evt => {
+              evt.preventDefault()
+              let quantity = parseInt($(`#number_of_cookie_${cookie.id}`).val())
+              plusItemzToCart(cookie, quantity)
+              alert(`Added ${quantity} ${cookie.name} to cart`)
+            }}
+          >
+            Add to cart
+          </a>
         </p>
       </div>
     </div>
   </div>
-);
+)

--- a/app/components/Products.jsx
+++ b/app/components/Products.jsx
@@ -1,24 +1,29 @@
-import React from 'react';
-import Nav from './Nav';
-import Footer from './Footer';
-import Product from './Product';
-import Hero from './Hero';
+import React from 'react'
+import Nav from './Nav'
+import Footer from './Footer'
+import Product from './Product'
+import Hero from './Hero'
 
 export default function (props) {
-
-  const products = props.products;
-  const plusItemzToCart = props.plusItemzToCart;
+  const products = props.products
+  const plusItemzToCart = props.plusItemzToCart
 
   return (
     <div>
       <div className="container">
-      <Hero />
+        <Hero />
         <div className="container">
           <div className="row">
-            {products.map( (cookie, index) => <Product key={index} cookie={cookie} plusItemzToCart={plusItemzToCart}/> )}
+            {products.map((cookie, index) => (
+              <Product
+                key={index}
+                cookie={cookie}
+                plusItemzToCart={plusItemzToCart}
+              />
+            ))}
           </div>
         </div>
       </div>
     </div>
-  );
+  )
 }

--- a/app/components/Reviews.jsx
+++ b/app/components/Reviews.jsx
@@ -1,12 +1,14 @@
-'use strict';
+'use strict'
 
-import React, { Component } from 'react';
-import {Link} from 'react-router';
+import React, { Component } from 'react'
+import { Link } from 'react-router'
 
 export default () => (
   <div className="container">
     <div>
-      <Link to="/products"><img className="cookieMonsterImg" src='/images/cookie-monster.jpg' /></Link>
+      <Link to="/products">
+        <img className="cookieMonsterImg" src="/images/cookie-monster.jpg" />
+      </Link>
       <h1>Cookie Monsters</h1>
       <h3 className="subtitle">Home of the world's greatest cookies</h3>
     </div>
@@ -14,7 +16,10 @@ export default () => (
     <div id="reviews" className="row">
       <div className="col-xs-12 col-sm-6 col-md-4">
         <div className="cookieContainer">
-          <img className="cookieImage" src="/images/cookies/chocolate-chip.jpg" />
+          <img
+            className="cookieImage"
+            src="/images/cookies/chocolate-chip.jpg"
+          />
         </div>
       </div>
       <div className="col-xs-12 col-sm-6 col-md-8">
@@ -23,13 +28,18 @@ export default () => (
         {/* Loop on this for product reviews */}
         {/* STARS - REVIEW TITLE: */}
         {/* Loop over stars to display by rating */}
-        <h4><i className="fa fa-star fa-lg reviewStar" aria-hidden="true"></i> Delicious</h4>
+        <h4>
+          <i className="fa fa-star fa-lg reviewStar" aria-hidden="true"></i>{' '}
+          Delicious
+        </h4>
         {/* REVIEW BODY by REVIEW.USER */}
         <div className="review">
-          <p className="reviewBody">I'm now fat and an addict. Thanks, Cookie Monsters. Nom nom nom.</p>
+          <p className="reviewBody">
+            I'm now fat and an addict. Thanks, Cookie Monsters. Nom nom nom.
+          </p>
           <p className="reviewUser">submitted by Rachel</p>
         </div>
       </div>
     </div>
   </div>
-);
+)

--- a/app/components/SignUp.jsx
+++ b/app/components/SignUp.jsx
@@ -1,23 +1,31 @@
 import React from 'react'
 
 export const Signup = ({ signup }) => (
-<div className="container">
-  <h1 className="display-4">Sign Up</h1>
-    <form onSubmit={evt => {
-      evt.preventDefault()
-      signup(evt.target.username.value, evt.target.password.value)
-    } }>
-      <input className="form-control auth-field" name="username" placeholder="Username" />
-      <input className="form-control auth-field" name="password" type="password" placeholder="Password" />
+  <div className="container">
+    <h1 className="display-4">Sign Up</h1>
+    <form
+      onSubmit={evt => {
+        evt.preventDefault()
+        signup(evt.target.username.value, evt.target.password.value)
+      }}
+    >
+      <input
+        className="form-control auth-field"
+        name="username"
+        placeholder="Username"
+      />
+      <input
+        className="form-control auth-field"
+        name="password"
+        type="password"
+        placeholder="Password"
+      />
       <input className="btn btn-primary" type="submit" value="Sign Up" />
     </form>
-</div>
+  </div>
 )
 
-import {signup} from '../reducers/auth'
-import {connect} from 'react-redux'
+import { signup } from '../reducers/auth'
+import { connect } from 'react-redux'
 
-export default connect (
-  state => ({}),
-  {signup},
-) (Signup)
+export default connect(state => ({}), { signup })(Signup)

--- a/app/components/User.jsx
+++ b/app/components/User.jsx
@@ -1,81 +1,168 @@
-'use strict';
+'use strict'
 
-import React, { Component } from 'react';
-import { Link, browserHistory } from 'react-router';
+import React, { Component } from 'react'
+import { Link, browserHistory } from 'react-router'
 
-export default (props) => {
-  let user = props.user;
-  if (user === "") {
-    browserHistory.push('/login');
+export default props => {
+  let user = props.user
+  if (user === '') {
+    browserHistory.push('/login')
   } else {
     return (
-    <div className="container">
-      <div className="col-xs-12 col-sm-4">
-        <h2>{user.name}</h2>
-        <div className="form-group">
-          <label htmlFor="name">Name</label>
-          <input type="text" className="form-control" id="name" aria-describedby="emailHelp" value={user.name} />
+      <div className="container">
+        <div className="col-xs-12 col-sm-4">
+          <h2>{user.name}</h2>
+          <div className="form-group">
+            <label htmlFor="name">Name</label>
+            <input
+              type="text"
+              className="form-control"
+              id="name"
+              aria-describedby="emailHelp"
+              value={user.name}
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="email">Email address</label>
+            <input
+              type="email"
+              className="form-control"
+              id="email"
+              aria-describedby="emailHelp"
+              value={user.email}
+            />
+            <small id="emailHelp" className="form-text text-muted">
+              We'll never share your email with anyone else.
+            </small>
+          </div>
+          <h4>Billing Address</h4>
+          <div className="form-group">
+            <label htmlFor="billingAddress">Address</label>
+            <input
+              type="text"
+              className="form-control"
+              id="billingAddress"
+              aria-describedby="billingAddress"
+              value={user.billingAddress}
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="billingCity">City</label>
+            <input
+              type="text"
+              className="form-control"
+              id="billingCity"
+              aria-describedby="billingCity"
+              value={user.billingCity}
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="billingState">State</label>
+            <input
+              type="text"
+              className="form-control"
+              id="billingState"
+              aria-describedby="billingState"
+              value={user.billingState}
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="billingZip">Zip Code</label>
+            <input
+              type="text"
+              className="form-control"
+              id="billingZip"
+              aria-describedby="billingZip"
+              value={user.billingZip}
+            />
+          </div>
+          <h4>Shipping Address</h4>
+          <div className="form-group">
+            <label htmlFor="shippingAddress">Address</label>
+            <input
+              type="text"
+              className="form-control"
+              id="shippingAddress"
+              aria-describedby="shippingAddress"
+              value={user.shippingAddress}
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="shippingCity">City</label>
+            <input
+              type="text"
+              className="form-control"
+              id="shippingCity"
+              aria-describedby="shippingCity"
+              value={user.shippingCity}
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="shippingState">State</label>
+            <input
+              type="text"
+              className="form-control"
+              id="shippingState"
+              aria-describedby="shippingState"
+              value={user.shippingState}
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="shippingZip">Zip Code</label>
+            <input
+              type="text"
+              className="form-control"
+              id="shippingZip"
+              aria-describedby="shippingZip"
+              value={user.billingZip}
+            />
+          </div>
+          {props.auth.isAdmin ? (
+            <fieldset className="form-group">
+              <legend>
+                {user.name}{' '}
+                {user.isAdmin
+                  ? 'is a site administrator'
+                  : 'is not a site administrator'}
+              </legend>
+              <div className="form-check">
+                <label className="form-check-label">
+                  <input
+                    type="radio"
+                    className="form-check-input"
+                    name="makeAdmin"
+                    id="makeAdmin"
+                    defaultValue="makeAdmin"
+                    disabled={user.isAdmin ? 'disabled' : false}
+                  />
+                  Make {user.name} an Administrator
+                </label>
+              </div>
+              <div className="form-check disabled">
+                <label className="form-check-label">
+                  <input
+                    type="radio"
+                    className="form-check-input"
+                    name="notAdmin"
+                    id="notAdmin"
+                    defaultValue="notAdmin"
+                    disabled={user.isAdmin ? false : 'disabled'}
+                  />
+                  Revoke {user.name}'s Administrator rights
+                </label>
+              </div>
+            </fieldset>
+          ) : (
+            ''
+          )}
+          <button type="submit" className="btn btn-primary">
+            Submit
+          </button>
+          <Link to="/users" className="btn btn-default cancel-btn">
+            Cancel
+          </Link>
         </div>
-        <div className="form-group">
-          <label htmlFor="email">Email address</label>
-          <input type="email" className="form-control" id="email" aria-describedby="emailHelp" value={user.email} />
-          <small id="emailHelp" className="form-text text-muted">We'll never share your email with anyone else.</small>
-        </div>
-        <h4>Billing Address</h4>
-        <div className="form-group">
-          <label htmlFor="billingAddress">Address</label>
-          <input type="text" className="form-control" id="billingAddress" aria-describedby="billingAddress" value={user.billingAddress} />
-        </div>
-        <div className="form-group">
-          <label htmlFor="billingCity">City</label>
-          <input type="text" className="form-control" id="billingCity" aria-describedby="billingCity" value={user.billingCity} />
-        </div>
-        <div className="form-group">
-          <label htmlFor="billingState">State</label>
-          <input type="text" className="form-control" id="billingState" aria-describedby="billingState" value={user.billingState} />
-        </div>
-        <div className="form-group">
-          <label htmlFor="billingZip">Zip Code</label>
-          <input type="text" className="form-control" id="billingZip" aria-describedby="billingZip" value={user.billingZip} />
-        </div>
-        <h4>Shipping Address</h4>
-        <div className="form-group">
-          <label htmlFor="shippingAddress">Address</label>
-          <input type="text" className="form-control" id="shippingAddress" aria-describedby="shippingAddress" value={user.shippingAddress} />
-        </div>
-        <div className="form-group">
-          <label htmlFor="shippingCity">City</label>
-          <input type="text" className="form-control" id="shippingCity" aria-describedby="shippingCity" value={user.shippingCity} />
-        </div>
-        <div className="form-group">
-          <label htmlFor="shippingState">State</label>
-          <input type="text" className="form-control" id="shippingState" aria-describedby="shippingState" value={user.shippingState} />
-        </div>
-        <div className="form-group">
-          <label htmlFor="shippingZip">Zip Code</label>
-          <input type="text" className="form-control" id="shippingZip" aria-describedby="shippingZip" value={user.billingZip} />
-        </div>
-        {props.auth.isAdmin ? (
-          <fieldset className="form-group">
-            <legend>{user.name} {user.isAdmin ? ('is a site administrator') : ('is not a site administrator') }</legend>
-            <div className="form-check">
-              <label className="form-check-label">
-                <input type="radio" className="form-check-input" name="makeAdmin" id="makeAdmin" defaultValue="makeAdmin" disabled={user.isAdmin ? ('disabled') : (false) } />
-                Make {user.name} an Administrator
-              </label>
-            </div>
-            <div className="form-check disabled">
-              <label className="form-check-label">
-                <input type="radio" className="form-check-input" name="notAdmin" id="notAdmin" defaultValue="notAdmin"  disabled={user.isAdmin ? false : ('disabled') } />
-                Revoke {user.name}'s Administrator rights
-              </label>
-            </div>
-          </fieldset> ) : '' }
-        <button type="submit" className="btn btn-primary">Submit</button>
-        <Link to="/users" className="btn btn-default cancel-btn">Cancel</Link>
       </div>
-    </div>
     )
   }
-};
-
+}

--- a/app/components/Users.jsx
+++ b/app/components/Users.jsx
@@ -1,23 +1,34 @@
-'use strict';
+'use strict'
 
-import React, { Component } from 'react';
-import { Link, browserHistory } from 'react-router';
+import React, { Component } from 'react'
+import { Link, browserHistory } from 'react-router'
 
-export default (props) => {
-  let users = props.users.users;
-  let selectedUser = props.users.selectedUser;
-  let selectUser = props.selectUser;
+export default props => {
+  let users = props.users.users
+  let selectedUser = props.users.selectedUser
+  let selectUser = props.selectUser
   return (
     <div className="container">
       <div className="col-xs-12 col-sm-4">
         <h2>All the Cookie Monsters</h2>
         <div id="users" className="list-group">
-          {users.map((user, index) => <li key={user.email} className="list-group-item list-group-item-action"><a onClick={(evt)=>{
-          evt.preventDefault();
-          selectUser(user);
-        }}>{user.name}</a></li> )}
+          {users.map((user, index) => (
+            <li
+              key={user.email}
+              className="list-group-item list-group-item-action"
+            >
+              <a
+                onClick={evt => {
+                  evt.preventDefault()
+                  selectUser(user)
+                }}
+              >
+                {user.name}
+              </a>
+            </li>
+          ))}
         </div>
       </div>
     </div>
   )
-};
+}

--- a/app/components/WhoAmI.jsx
+++ b/app/components/WhoAmI.jsx
@@ -3,14 +3,13 @@ import React from 'react'
 export const WhoAmI = ({ user, logout }) => (
   <div className="whoami">
     <span className="whoami-user-name">{user && user.name}</span>
-    <button className="logout" onClick={logout}>Logout</button>
+    <button className="logout" onClick={logout}>
+      Logout
+    </button>
   </div>
 )
 
-import {logout} from '../reducers/auth'
-import {connect} from 'react-redux'
+import { logout } from '../reducers/auth'
+import { connect } from 'react-redux'
 
-export default connect (
-  ({ auth }) => ({ user: auth }),
-  {logout},
-) (WhoAmI)
+export default connect(({ auth }) => ({ user: auth }), { logout })(WhoAmI)

--- a/app/components/WhoAmI.test.jsx
+++ b/app/components/WhoAmI.test.jsx
@@ -1,21 +1,22 @@
 import React from 'react'
-import chai, {expect} from 'chai'                                                   
+import chai, { expect } from 'chai'
 chai.use(require('chai-enzyme')())
-import {shallow} from 'enzyme'
-import {spy} from 'sinon'
+import { shallow } from 'enzyme'
+import { spy } from 'sinon'
 chai.use(require('sinon-chai'))
-import {createStore} from 'redux'
+import { createStore } from 'redux'
 
-import WhoAmIContainer, {WhoAmI} from './WhoAmI'
+import WhoAmIContainer, { WhoAmI } from './WhoAmI'
 
 describe('<WhoAmI/>', () => {
   const user = {
     name: 'Dr. Bones',
   }
-  const logout = spy() 
+  const logout = spy()
   let root
-  beforeEach('render the root', () =>
-    root = shallow(<WhoAmI user={user} logout={logout}/>)
+  beforeEach(
+    'render the root',
+    () => (root = shallow(<WhoAmI user={user} logout={logout} />))
   )
 
   it('greets the user', () => {
@@ -34,14 +35,14 @@ describe('<WhoAmI/>', () => {
 
 describe("<WhoAmI/>'s connection", () => {
   const state = {
-    auth: {name: 'Dr. Bones'}
+    auth: { name: 'Dr. Bones' },
   }
-  
+
   let root, store, dispatch
   beforeEach('create store and render the root', () => {
     store = createStore(state => state, state)
     dispatch = spy(store, 'dispatch')
-    root = shallow(<WhoAmIContainer store={store}/>)
+    root = shallow(<WhoAmIContainer store={store} />)
   })
 
   it('gets prop.user from state.auth', () => {

--- a/app/containers/AppContainer.jsx
+++ b/app/containers/AppContainer.jsx
@@ -1,11 +1,11 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import App from '../components/App';
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import App from '../components/App'
 
 function mapStateToProps(state) {
   return {
-    products: state.products
-  };
+    products: state.products,
+  }
 }
 
-export default connect(mapStateToProps)(App);
+export default connect(mapStateToProps)(App)

--- a/app/containers/CartContainer.jsx
+++ b/app/containers/CartContainer.jsx
@@ -1,10 +1,10 @@
-import { connect } from 'react-redux';
-import Cart from '../components/Cart';
+import { connect } from 'react-redux'
+import Cart from '../components/Cart'
 
 function mapStateToProps(state) {
   return {
-    cart: state.cart
+    cart: state.cart,
   }
-};
+}
 
-export default connect(mapStateToProps)(Cart);
+export default connect(mapStateToProps)(Cart)

--- a/app/containers/CartViewContainer.jsx
+++ b/app/containers/CartViewContainer.jsx
@@ -1,21 +1,20 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import CartView from '../components/CartView';
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import CartView from '../components/CartView'
 import { submitOrder } from '../reducers/orders.jsx'
 
 function mapStateToProps(state) {
   return {
-    cart: state.cart
-  };
+    cart: state.cart,
+  }
 }
 
 function mapDispatchToProps(dispatch) {
   return {
-    submitOrder: (cart) => {
-      dispatch(submitOrder(cart));
-    }
+    submitOrder: cart => {
+      dispatch(submitOrder(cart))
+    },
   }
 }
 
-
-export default connect(mapStateToProps, mapDispatchToProps)(CartView);
+export default connect(mapStateToProps, mapDispatchToProps)(CartView)

--- a/app/containers/LoginContainer.jsx
+++ b/app/containers/LoginContainer.jsx
@@ -1,18 +1,14 @@
-import Login from '../components/Login.jsx';
-import {login} from '../reducers/auth';
-import {connect} from 'react-redux';
-import {browserHistory} from 'react-router';
+import Login from '../components/Login.jsx'
+import { login } from '../reducers/auth'
+import { connect } from 'react-redux'
+import { browserHistory } from 'react-router'
 
 function mapDispatchToProps(dispatch) {
   return {
     login: (username, password) => {
-      dispatch(login(username, password));
-      browserHistory.push('/');
-
-    }
+      dispatch(login(username, password))
+      browserHistory.push('/')
+    },
   }
 }
-export default connect (
-  null,
-  mapDispatchToProps,
-) (Login)
+export default connect(null, mapDispatchToProps)(Login)

--- a/app/containers/MyOrdersContainer.jsx
+++ b/app/containers/MyOrdersContainer.jsx
@@ -1,21 +1,21 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import MyOrders from '../components/MyOrders';
-import { selectOrder } from '../reducers/orders';
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import MyOrders from '../components/MyOrders'
+import { selectOrder } from '../reducers/orders'
 
 function mapStateToProps(state) {
   return {
-    orders: state.orders.orders
-  };
+    orders: state.orders.orders,
+  }
 }
 
 function mapDispatchToProps(dispatch) {
   return {
-    selectOrder: (order) => {
-      dispatch(selectOrder(order));
+    selectOrder: order => {
+      dispatch(selectOrder(order))
       // browserHistory.push('/user');
-    }
+    },
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(MyOrders);
+export default connect(mapStateToProps, mapDispatchToProps)(MyOrders)

--- a/app/containers/NavContainer.jsx
+++ b/app/containers/NavContainer.jsx
@@ -1,27 +1,27 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import Nav from '../components/Nav';
-import { selectUser } from '../reducers/users';
-import { logout } from '../reducers/auth';
-import {browserHistory} from 'react-router';
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import Nav from '../components/Nav'
+import { selectUser } from '../reducers/users'
+import { logout } from '../reducers/auth'
+import { browserHistory } from 'react-router'
 
 function mapStateToProps(state) {
   return {
-    auth: state.auth
-  };
+    auth: state.auth,
+  }
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     logout: () => {
       dispatch(logout())
-      browserHistory.push('/');
+      browserHistory.push('/')
     },
-    selectUser: (user) => {
-      dispatch(selectUser(user));
-      browserHistory.push('/user');
-    }
+    selectUser: user => {
+      dispatch(selectUser(user))
+      browserHistory.push('/user')
+    },
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(Nav);
+export default connect(mapStateToProps, mapDispatchToProps)(Nav)

--- a/app/containers/OrderContainer.jsx
+++ b/app/containers/OrderContainer.jsx
@@ -1,9 +1,9 @@
-import Order from '../components/Order.jsx';
-import { connect } from 'react-redux';
+import Order from '../components/Order.jsx'
+import { connect } from 'react-redux'
 
 function mapStateToProps(state) {
   return {
-    order: state.orders.selectedOrder
+    order: state.orders.selectedOrder,
   }
 }
 

--- a/app/containers/ProductsContainer.jsx
+++ b/app/containers/ProductsContainer.jsx
@@ -1,20 +1,20 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import Products from '../components/Products';
-import {addToCart} from '../reducers/cart';
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import Products from '../components/Products'
+import { addToCart } from '../reducers/cart'
 
 function mapStateToProps(state) {
   return {
-    products: state.products
-  };
+    products: state.products,
+  }
 }
 
 function mapDispatchToProps(dispatch) {
   return {
     plusItemzToCart: (product, quantity) => {
       dispatch(addToCart(product, quantity))
-    }
+    },
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(Products);
+export default connect(mapStateToProps, mapDispatchToProps)(Products)

--- a/app/containers/UserContainer.jsx
+++ b/app/containers/UserContainer.jsx
@@ -1,10 +1,10 @@
-import User from '../components/User.jsx';
-import { connect } from 'react-redux';
+import User from '../components/User.jsx'
+import { connect } from 'react-redux'
 
 function mapStateToProps(state) {
   return {
     user: state.users.selectedUser,
-    auth: state.auth
+    auth: state.auth,
   }
 }
 
@@ -17,7 +17,5 @@ function mapStateToProps(state) {
 //     }
 //   }
 // }
-
-
 
 export default connect(mapStateToProps)(User)

--- a/app/containers/UsersContainer.jsx
+++ b/app/containers/UsersContainer.jsx
@@ -1,21 +1,21 @@
-import Users from '../components/Users.jsx';
-import { connect } from 'react-redux';
-import { selectUser } from '../reducers/users';
-import {browserHistory} from 'react-router';
+import Users from '../components/Users.jsx'
+import { connect } from 'react-redux'
+import { selectUser } from '../reducers/users'
+import { browserHistory } from 'react-router'
 
 function mapStateToProps(state) {
   return {
     users: state.users,
-    auth: state.auth
+    auth: state.auth,
   }
 }
 
 function mapDispatchToProps(dispatch) {
   return {
-    selectUser: (user) => {
-      dispatch(selectUser(user));
-      browserHistory.push('/user');
-    }
+    selectUser: user => {
+      dispatch(selectUser(user))
+      browserHistory.push('/user')
+    },
   }
 }
 

--- a/app/main.jsx
+++ b/app/main.jsx
@@ -1,25 +1,25 @@
 'use strict'
 import React from 'react'
-import { Router, Route, IndexRedirect, browserHistory } from 'react-router';
-import { render } from 'react-dom';
-import { connect, Provider } from 'react-redux';
-import axios from 'axios';
-import { receiveProducts } from './reducers/products';
+import { Router, Route, IndexRedirect, browserHistory } from 'react-router'
+import { render } from 'react-dom'
+import { connect, Provider } from 'react-redux'
+import axios from 'axios'
+import { receiveProducts } from './reducers/products'
 // TODO: Make sure that this func acts similarly to receiveProducts
-import { receiveUsers } from './reducers/users';
-import { receiveOrders } from './reducers/orders';
-import store from './store';
+import { receiveUsers } from './reducers/users'
+import { receiveOrders } from './reducers/orders'
+import store from './store'
 
-import AppContainer from './containers/AppContainer';
-import CartViewContainer from './containers/CartViewContainer';
-import LoginContainer from './containers/LoginContainer';
-import SignUp from './components/SignUp';
-import Order from './containers/OrderContainer';
-import MyOrders from './containers/MyOrdersContainer';
-import ProductsContainer from './containers/ProductsContainer';
-import UserContainer from './containers/UserContainer';
-import UsersContainer from './containers/UsersContainer';
-import Reviews from './components/Reviews';
+import AppContainer from './containers/AppContainer'
+import CartViewContainer from './containers/CartViewContainer'
+import LoginContainer from './containers/LoginContainer'
+import SignUp from './components/SignUp'
+import Order from './containers/OrderContainer'
+import MyOrders from './containers/MyOrdersContainer'
+import ProductsContainer from './containers/ProductsContainer'
+import UserContainer from './containers/UserContainer'
+import UsersContainer from './containers/UsersContainer'
+import Reviews from './components/Reviews'
 
 /* Commenting out example app because we can mimic its functionality, perhaps in the Navbar component
    Also: referencing Auther workshop for basic 'root' react component heirarchy (not for code style, but for structure)
@@ -40,38 +40,40 @@ const ExampleApp = connect(
 */
 
 const onAppEnter = function () {
-  axios.get('/api/products')
-    .then(products => {
-      store.dispatch(receiveProducts(products.data));
-    });
-};
-
+  axios.get('/api/products').then(products => {
+    store.dispatch(receiveProducts(products.data))
+  })
+}
 
 const onUsersEnter = function () {
   //if user is an admin
-  store.dispatch(receiveUsers());
-};
+  store.dispatch(receiveUsers())
+}
 
 const onOrdersEnter = function () {
-  store.dispatch(receiveOrders());
-};
+  store.dispatch(receiveOrders())
+}
 
 render(
   <Provider store={store}>
     <Router history={browserHistory}>
       <Route path="/" component={AppContainer} onEnter={onAppEnter}>
         <Route path="/products" component={ProductsContainer} />
-        <Route path="/viewcart" component={ CartViewContainer } />
+        <Route path="/viewcart" component={CartViewContainer} />
         <Route path="/order" component={Order} />
         <Route path="/reviews" component={Reviews} />
         <Route path="/signup" component={SignUp} />
         <Route path="/login" component={LoginContainer} />
-        <Route path="/users" component={UsersContainer} onEnter={onUsersEnter}/>
+        <Route
+          path="/users"
+          component={UsersContainer}
+          onEnter={onUsersEnter}
+        />
         <Route path="/user" component={UserContainer} />
-        <Route path="/myorders" component={MyOrders} onEnter={onOrdersEnter}/>
+        <Route path="/myorders" component={MyOrders} onEnter={onOrdersEnter} />
         <IndexRedirect to="/products" />
       </Route>
     </Router>
   </Provider>,
   document.getElementById('main')
-);
+)

--- a/app/reducers/auth.jsx
+++ b/app/reducers/auth.jsx
@@ -10,7 +10,8 @@ const reducer = (state = null, action) => {
 
 const AUTHENTICATED = 'AUTHENTICATED'
 export const authenticated = user => ({
-  type: AUTHENTICATED, user
+  type: AUTHENTICATED,
+  user,
 })
 
 // wipeLocalState is an action creator that dispatches an action that the rrot reducer uses as a hook
@@ -20,44 +21,42 @@ export const authenticated = user => ({
 
 const WIPELOCALSTATE = 'WIPELOCALSTATE'
 export const wipeLocalState = () => ({
-  type: WIPELOCALSTATE
+  type: WIPELOCALSTATE,
 })
 
-export const login = (username, password) =>
-  dispatch =>
-    axios.post('/api/auth/local/login',
-      { username, password })
-      .then(() => dispatch(whoami()))
-      .catch(() => dispatch(whoami()))
+export const login = (username, password) => dispatch =>
+  axios
+    .post('/api/auth/local/login', { username, password })
+    .then(() => dispatch(whoami()))
+    .catch(() => dispatch(whoami()))
 
-export const signup = (username, password) =>
-  dispatch =>
-    axios.post('/api/auth/local/signup',
-      { username, password })
-      .then(() => dispatch(whoami()))
-      .catch(() => dispatch(whoami()))
+export const signup = (username, password) => dispatch =>
+  axios
+    .post('/api/auth/local/signup', { username, password })
+    .then(() => dispatch(whoami()))
+    .catch(() => dispatch(whoami()))
 
-export const logout = () =>
-  dispatch => {
-    console.log('dispatch: ', dispatch)
-    axios.post('/api/auth/logout')
-      .then(() => {
-        dispatch(whoami());
-        dispatch(wipeLocalState());
-      })
-      .catch(() => {
-        dispatch(whoami());
-        dispatch(wipeLocalState());
-      })
-  }
+export const logout = () => dispatch => {
+  console.log('dispatch: ', dispatch)
+  axios
+    .post('/api/auth/logout')
+    .then(() => {
+      dispatch(whoami())
+      dispatch(wipeLocalState())
+    })
+    .catch(() => {
+      dispatch(whoami())
+      dispatch(wipeLocalState())
+    })
+}
 
-export const whoami = () =>
-  dispatch =>
-    axios.get('/api/auth/whoami')
-      .then(response => {
-        const user = response.data
-        dispatch(authenticated(user))
-      })
-      .catch(failed => dispatch(authenticated(null)))
+export const whoami = () => dispatch =>
+  axios
+    .get('/api/auth/whoami')
+    .then(response => {
+      const user = response.data
+      dispatch(authenticated(user))
+    })
+    .catch(failed => dispatch(authenticated(null)))
 
 export default reducer

--- a/app/reducers/cart.jsx
+++ b/app/reducers/cart.jsx
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from 'axios'
 
 // Example order object
 // "order": {
@@ -13,70 +13,69 @@ import axios from 'axios';
 // }
 
 // Constant
-const ADD_TO_CART = 'ADD_TO_CART';
-const EMPTY_CART = 'EMPTY_CART';
+const ADD_TO_CART = 'ADD_TO_CART'
+const EMPTY_CART = 'EMPTY_CART'
 
 // Reducer
 const reducer = (lineItems = [], action) => {
-
   switch (action.type) {
     case ADD_TO_CART:
-      console.log("Starting ADD_TO_CART");
+      console.log('Starting ADD_TO_CART')
       // Clone lineItems to be a pure function
-      let newCart = [...lineItems];
+      let newCart = [...lineItems]
       // Create while loop to break when match is found
-      let index = 0;
-      let foundMatchingItemInCart = false; // we are not sure yet
+      let index = 0
+      let foundMatchingItemInCart = false // we are not sure yet
       // so we search the items in the cart
       while (!foundMatchingItemInCart && index < newCart.length) {
-        console.log("Inside of while loop");
+        console.log('Inside of while loop')
         // If we are adding quantity to an item already represented by a line item in the cart
         if (newCart[index].product.id === action.lineItem.product.id) {
-          console.log("Start of match found");
+          console.log('Start of match found')
           // Update the quantity of the existing line item in the cart
-          newCart[index].quantity += action.lineItem.quantity;
-          foundMatchingItemInCart = true;
-          console.log("Appending quantity to existing cart line item");
+          newCart[index].quantity += action.lineItem.quantity
+          foundMatchingItemInCart = true
+          console.log('Appending quantity to existing cart line item')
         }
-        index++;
+        index++
       }
       // Otherwise add a new line item to the cart.
       if (!foundMatchingItemInCart) {
-        newCart.push(action.lineItem);
-        console.log("Adding new line item to cart");
+        newCart.push(action.lineItem)
+        console.log('Adding new line item to cart')
       }
       // And then save the cart as a string to localstorage under the key cart
       localStorage.setItem('cart', JSON.stringify(newCart))
       // And then return the new cart to redux
-      return newCart;
+      return newCart
     case EMPTY_CART:
-      localStorage.removeItem('cart');
-      return [];
+      localStorage.removeItem('cart')
+      return []
     default:
       // If the Redux store is empty, check to see if there is cart state frozen in localStorage under 'cart'
-      let defrostedCart = localStorage.getItem('cart');
+      let defrostedCart = localStorage.getItem('cart')
       if (defrostedCart) {
         // and return it if there is.
         return JSON.parse(defrostedCart)
       } else {
         // Otherwise, just return the default params of lineItems
-        return lineItems;
+        return lineItems
       }
   } // state.cart
-};
+}
 
 // Action Creator
 export function addToCart(product, quantity) {
   return {
     type: ADD_TO_CART,
-    lineItem: { product, quantity }
-  };
+    lineItem: { product, quantity },
+  }
 }
 
-export function emptyCart(){
+export function emptyCart() {
   return {
-    type: EMPTY_CART
-  };
+    type: EMPTY_CART,
+  }
 }
 
-export default reducer;
+export default reducer

--- a/app/reducers/index.jsx
+++ b/app/reducers/index.jsx
@@ -10,14 +10,14 @@ const appReducer = combineReducers({
   products: require('./products').default,
   cart: require('./cart').default,
   users: require('./users').default,
-  orders: require('./orders').default
+  orders: require('./orders').default,
 })
 
 const rootReducer = (state, action) => {
   if (action.type === 'WIPELOCALSTATE') {
-    localStorage.clear();
-    state.cart = [];
-    state.users = initialUsersState;
+    localStorage.clear()
+    state.cart = []
+    state.users = initialUsersState
   }
   return appReducer(state, action)
 }

--- a/app/reducers/orders.jsx
+++ b/app/reducers/orders.jsx
@@ -1,80 +1,83 @@
-import axios from 'axios';
-import { emptyCart } from './cart';
-import { browserHistory } from 'react-router';
+import axios from 'axios'
+import { emptyCart } from './cart'
+import { browserHistory } from 'react-router'
 
 // Constants
-const GET_ORDERS = 'GET_ORDERS';
-const SELECT_ORDER = 'SELECT_ORDERS';
+const GET_ORDERS = 'GET_ORDERS'
+const SELECT_ORDER = 'SELECT_ORDERS'
 
 // Reducers
 export const initialOrdersState = {
   orders: [],
-  selectedOrder: {}
-};
+  selectedOrder: {},
+}
 
 const reducer = (state = initialOrdersState, action) => {
-
-  const newState = Object.assign({}, state);
+  const newState = Object.assign({}, state)
 
   switch (action.type) {
     case GET_ORDERS:
-      newState.orders = action.orders;
-      break;
+      newState.orders = action.orders
+      break
     case SELECT_ORDER:
-      newState.selectedOrder = action.selectedOrder;
-      break;
+      newState.selectedOrder = action.selectedOrder
+      break
     default:
-      return state;
+      return state
   }
   return newState
-};
+}
 
 // Actions
 export const getOrders = orders => ({
-  type: GET_ORDERS, orders
-});
+  type: GET_ORDERS,
+  orders,
+})
 
 export const selectOrder = selectedOrder => ({
-  type: SELECT_ORDER, selectedOrder
-});
+  type: SELECT_ORDER,
+  selectedOrder,
+})
 
 export function receiveOrders() {
-  console.log("Receiving Orders");
+  console.log('Receiving Orders')
   // Return a thunk
   return function (dispatch) {
-    axios.get('/api/orders/')
-      .then((res) => dispatch(getOrders(res.data)))
-      .catch((err) => alert(err))
+    axios
+      .get('/api/orders/')
+      .then(res => dispatch(getOrders(res.data)))
+      .catch(err => alert(err))
   }
 }
 
 export function submitOrder(cart) {
-  [
+  ;[
     {
       product: {},
-      quantity: 1
-    }
+      quantity: 1,
+    },
   ]
 
-  let orderLineItems = {};
+  let orderLineItems = {}
   cart.forEach(item => {
-    let itemObj = { quantity: item.quantity };
-    orderLineItems[item.product.id] = itemObj;
+    let itemObj = { quantity: item.quantity }
+    orderLineItems[item.product.id] = itemObj
   })
   let order = {
     shippingCarrier: 'UPS',
-    orderLineItems: orderLineItems
+    orderLineItems: orderLineItems,
   }
   let data = JSON.stringify(order)
-  console.log(data);
+  console.log(data)
   return function (dispatch) {
-    axios.post('/api/orders/', order)
-      .then((order) => {
-        alert('Cookies are on the way!');
-        dispatch(emptyCart());
-        browserHistory.push('/myOrders');
+    axios
+      .post('/api/orders/', order)
+      .then(order => {
+        alert('Cookies are on the way!')
+        dispatch(emptyCart())
+        browserHistory.push('/myOrders')
       })
-      .catch((err) => alert(err))
+      .catch(err => alert(err))
   }
 }
 

--- a/app/reducers/products.jsx
+++ b/app/reducers/products.jsx
@@ -1,23 +1,22 @@
-import axios from 'axios';
+import axios from 'axios'
 
-const reducer = (state=[], action) => {
+const reducer = (state = [], action) => {
+  let newState = Object.assign({}, state)
 
-  let newState = Object.assign({}, state);
-
-  switch(action.type) {
+  switch (action.type) {
     case RECEIVE_PRODUCTS:
-      newState = action.products;
-      break;
+      newState = action.products
+      break
     default:
-      return state;
+      return state
   }
   return newState
 }
 
 const RECEIVE_PRODUCTS = 'RECEIVE_PRODUCTS'
 export const receiveProducts = products => ({
-    type: RECEIVE_PRODUCTS,
-    products
-});
+  type: RECEIVE_PRODUCTS,
+  products,
+})
 
 export default reducer

--- a/app/reducers/users.jsx
+++ b/app/reducers/users.jsx
@@ -1,48 +1,50 @@
-import axios from 'axios';
+import axios from 'axios'
 
 // Constants
-const GET_USERS = 'GET_USERS';
-const SELECT_USER = 'SELECT_USER';
+const GET_USERS = 'GET_USERS'
+const SELECT_USER = 'SELECT_USER'
 
 // Reducers
 export const initialUsersState = {
   users: [],
-  selectedUser: {}
-};
+  selectedUser: {},
+}
 
 const reducer = (state = initialUsersState, action) => {
-
-  const newState = Object.assign({}, state);
+  const newState = Object.assign({}, state)
 
   switch (action.type) {
     case GET_USERS:
-      newState.users = action.users;
-      break;
+      newState.users = action.users
+      break
     case SELECT_USER:
-      newState.selectedUser = action.selectedUser;
-      break;
+      newState.selectedUser = action.selectedUser
+      break
     default:
-      return state;
+      return state
   }
   return newState
-};
+}
 
 // Actions
 export const getUsers = users => ({
-  type: GET_USERS, users
-});
+  type: GET_USERS,
+  users,
+})
 
 export const selectUser = selectedUser => ({
-  type: SELECT_USER, selectedUser
-});
+  type: SELECT_USER,
+  selectedUser,
+})
 
 export function receiveUsers() {
-  console.log("Receiving Users");
+  console.log('Receiving Users')
   // Return a thunk
   return function (dispatch) {
-    axios.get('/api/users/')
-      .then((res) => dispatch(getUsers(res.data)))
-      .catch((err) => alert(err))
+    axios
+      .get('/api/users/')
+      .then(res => dispatch(getUsers(res.data)))
+      .catch(err => alert(err))
   }
 }
 

--- a/app/store.jsx
+++ b/app/store.jsx
@@ -3,11 +3,14 @@ import rootReducer from './reducers'
 import createLogger from 'redux-logger'
 import thunkMiddleware from 'redux-thunk'
 
-import {whoami} from './reducers/auth'
+import { whoami } from './reducers/auth'
 
-const store = createStore(rootReducer, applyMiddleware(createLogger(), thunkMiddleware))
+const store = createStore(
+  rootReducer,
+  applyMiddleware(createLogger(), thunkMiddleware)
+)
 
 export default store
 
 // Set the auth info at start
-store.dispatch(whoami()) 
+store.dispatch(whoami())

--- a/db/index.js
+++ b/db/index.js
@@ -4,30 +4,31 @@ const chalk = require('chalk')
 const Sequelize = require('sequelize')
 const app = require('../index.js')
 
-const name = (process.env.DATABASE_NAME || app.name) +
-  (app.isTesting ? '_test' : '')
+const name =
+  (process.env.DATABASE_NAME || app.name) + (app.isTesting ? '_test' : '')
 
 const url = process.env.DATABASE_URL || `postgres://localhost:5432/${name}`
 
-console.log(chalk.yellow(`Opening database connection to ${url}`));
+console.log(chalk.yellow(`Opening database connection to ${url}`))
 
 // create the database instance
-const db = module.exports = new Sequelize(url, {
+const db = (module.exports = new Sequelize(url, {
   logging: debug, // export DEBUG=sql in the environment to get SQL queries
-  native: false,   // lets Sequelize know we can use pg-native for ~30% more speed
+  native: false, // lets Sequelize know we can use pg-native for ~30% more speed
   define: {
-    underscored: true,       // use snake_case rather than camelCase column names
-    freezeTableName: true,   // don't change table names from the one specified
-    timestamps: true,        // automatically include timestamp columns
-  }
-})
+    underscored: true, // use snake_case rather than camelCase column names
+    freezeTableName: true, // don't change table names from the one specified
+    timestamps: true, // automatically include timestamp columns
+  },
+}))
 
 // pull in our models
 require('./models')
 
 // sync the db, creating it if necessary
-function sync(force=app.isTesting, retries=0, maxRetries=5) {
-  return db.sync({force})
+function sync(force = app.isTesting, retries = 0, maxRetries = 5) {
+  return db
+    .sync({ force })
     .then(ok => console.log(`Synced models to db ${url}`))
     .catch(fail => {
       // Don't do this auto-create nonsense in prod, or
@@ -41,7 +42,9 @@ function sync(force=app.isTesting, retries=0, maxRetries=5) {
         return
       }
       // Otherwise, do this autocreate nonsense
-      console.log(`${retries ? `[retry ${retries}]` : ''} Creating database ${name}...`)
+      console.log(
+        `${retries ? `[retry ${retries}]` : ''} Creating database ${name}...`
+      )
       return new Promise((resolve, reject) =>
         require('child_process').exec(`createdb "${name}"`, resolve)
       ).then(() => sync(true, retries + 1))

--- a/db/models/index.js
+++ b/db/models/index.js
@@ -1,19 +1,19 @@
-'use strict';
+'use strict'
 
 // Require our models. Running each module registers the model into sequelize
 // so any other part of the application could call sequelize.model('User')
 // to get access to the User model.
 
-const User = require('./user');
-const Product = require('./product');
-const Order = require('./order');
-const OrderLineItem = require('./orderLineItem');
-const Review = require('./review');
+const User = require('./user')
+const Product = require('./product')
+const Order = require('./order')
+const OrderLineItem = require('./orderLineItem')
+const Review = require('./review')
 
-Order.belongsToMany(Product, { through: OrderLineItem });
-Product.belongsToMany(Order, { through: OrderLineItem });
-Product.hasMany(Review);
-User.hasMany(Review);
-User.hasMany(Order);
+Order.belongsToMany(Product, { through: OrderLineItem })
+Product.belongsToMany(Order, { through: OrderLineItem })
+Product.hasMany(Review)
+User.hasMany(Review)
+User.hasMany(Order)
 
-module.exports = {User};
+module.exports = { User }

--- a/db/models/oauth.js
+++ b/db/models/oauth.js
@@ -4,35 +4,42 @@ const debug = require('debug')('oauth')
 const Sequelize = require('sequelize')
 const db = require('../../db')
 
-const OAuth = db.define('oauths', {
-  uid: Sequelize.STRING,
-  provider: Sequelize.STRING,
+const OAuth = db.define(
+  'oauths',
+  {
+    uid: Sequelize.STRING,
+    provider: Sequelize.STRING,
 
-  // OAuth v2 fields
-  accessToken: Sequelize.STRING,
-  refreshToken: Sequelize.STRING,
+    // OAuth v2 fields
+    accessToken: Sequelize.STRING,
+    refreshToken: Sequelize.STRING,
 
-  // OAuth v1 fields
-  token: Sequelize.STRING,
-  tokenSecret: Sequelize.STRING,
+    // OAuth v1 fields
+    token: Sequelize.STRING,
+    tokenSecret: Sequelize.STRING,
 
-  // The whole profile as JSON
-  profileJson: Sequelize.JSON,
-}, {
-	indexes: [{fields: ['uid'], unique: true,}],
-})
+    // The whole profile as JSON
+    profileJson: Sequelize.JSON,
+  },
+  {
+    indexes: [{ fields: ['uid'], unique: true }],
+  }
+)
 
 OAuth.V2 = (accessToken, refreshToken, profile, done) =>
   this.findOrCreate({
     where: {
       provider: profile.provider,
       uid: profile.id,
-    }})
+    },
+  })
     .then(oauth => {
-      debug('provider:%s will log in user:{name=%s uid=%s}',
+      debug(
+        'provider:%s will log in user:{name=%s uid=%s}',
         profile.provider,
         profile.displayName,
-        token.uid)
+        token.uid
+      )
       oauth.profileJson = profile
       return db.Promise.props({
         oauth,
@@ -40,32 +47,35 @@ OAuth.V2 = (accessToken, refreshToken, profile, done) =>
         _saveProfile: oauth.save(),
       })
     })
-    .then(({ oauth, user }) => user ||
-      User.create({
-        name: profile.displayName,
-      }).then(user => db.Promise.props({
-        user,
-        _setOauthUser: oauth.setUser(user)
-      }))
+    .then(
+      ({ oauth, user }) =>
+        user ||
+        User.create({
+          name: profile.displayName,
+        }).then(user =>
+          db.Promise.props({
+            user,
+            _setOauthUser: oauth.setUser(user),
+          })
+        )
     )
     .then(({ user }) => done(null, user))
     .catch(done)
 
-
-OAuth.setupStrategy =
-({
+OAuth.setupStrategy = ({
   provider,
   strategy,
   config,
-  oauth=OAuth.V2,
-  passport
+  oauth = OAuth.V2,
+  passport,
 }) => {
   const undefinedKeys = Object.keys(config)
-        .map(k => config[k])
-        .filter(value => typeof value === 'undefined')
+    .map(k => config[k])
+    .filter(value => typeof value === 'undefined')
   if (undefinedKeys.length) {
     undefinedKeys.forEach(key =>
-      debug('provider:%s: needs environment var %s', provider, key))
+      debug('provider:%s: needs environment var %s', provider, key)
+    )
     debug('provider:%s will not initialize', provider)
     return
   }

--- a/db/models/order.js
+++ b/db/models/order.js
@@ -3,44 +3,44 @@
 const Sequelize = require('sequelize')
 const db = require('../../db')
 
-const Order = db.define('orders', {
-
-  status: {
-    type: Sequelize.ENUM('created', 'processing', 'cancelled', 'completed'),
-    defaultValue: 'created',
-    allowNull: false
+const Order = db.define(
+  'orders',
+  {
+    status: {
+      type: Sequelize.ENUM('created', 'processing', 'cancelled', 'completed'),
+      defaultValue: 'created',
+      allowNull: false,
+    },
+    shippingRate: {
+      type: Sequelize.DECIMAL(16, 2),
+      defaultValue: 3.95,
+      validate: {
+        notEmpty: true,
+      },
+    },
+    shippingCarrier: {
+      type: Sequelize.ENUM('USPS', 'UPS', 'FedEx'),
+      allowNull: true,
+    },
+    trackingNumber: {
+      type: Sequelize.STRING,
+      allowNull: true,
+    },
   },
-  shippingRate: {
-    type: Sequelize.DECIMAL(16, 2),
-    defaultValue: 3.95,
-    validate: {
-      notEmpty: true
-    }
-  },
-  shippingCarrier: {
-    type: Sequelize.ENUM('USPS', 'UPS', 'FedEx'),
-    allowNull: true
-  },
-  trackingNumber: {
-    type: Sequelize.STRING,
-    allowNull: true
-  }
-}
-  , {
+  {
     getterMethods: {
       total: function () {
-        let runningTotal = 0.00;
-        return this.getProducts()
-          .then(products => {
-            products.forEach(
-              product => runningTotal += product.orderLineItems.subtotal
-            )
-            runningTotal += parseFloat(this.shippingRate)
-            console.log(runningTotal);
-            return runningTotal;
-          })
-      }
-    }
+        let runningTotal = 0.0
+        return this.getProducts().then(products => {
+          products.forEach(
+            product => (runningTotal += product.orderLineItems.subtotal)
+          )
+          runningTotal += parseFloat(this.shippingRate)
+          console.log(runningTotal)
+          return runningTotal
+        })
+      },
+    },
   }
 )
 

--- a/db/models/orderLineItem.js
+++ b/db/models/orderLineItem.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const Order = require('./order.js');
-const Product = require('./product.js');
-const Sequelize = require('sequelize');
-const db = require('../../db');
+const Order = require('./order.js')
+const Product = require('./product.js')
+const Sequelize = require('sequelize')
+const db = require('../../db')
 
 // An OrderLineItem is effectively a join table with extra attributes
 
@@ -15,28 +15,31 @@ const db = require('../../db');
 //   price: selectedProduct.price
 // })
 
-const OrderLineItem = db.define('orderLineItems', {
-  quantity: {
-    type: Sequelize.INTEGER,
-    allowNull: false,
-    validate: {
-      notEmpty: true
-    }
+const OrderLineItem = db.define(
+  'orderLineItems',
+  {
+    quantity: {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      validate: {
+        notEmpty: true,
+      },
+    },
+    price: {
+      type: Sequelize.DECIMAL(16, 2),
+      allowNull: false,
+      validate: {
+        notEmpty: true,
+      },
+    },
   },
-  price: {
-    type: Sequelize.DECIMAL(16, 2),
-    allowNull: false,
-    validate: {
-      notEmpty: true
-    }
-  }
-}, {
+  {
     getterMethods: {
       subtotal: function () {
-        return this.quantity * this.price;
-      }
-    }
+        return this.quantity * this.price
+      },
+    },
   }
-);
+)
 
 module.exports = OrderLineItem

--- a/db/models/product.js
+++ b/db/models/product.js
@@ -1,45 +1,46 @@
-'use strict';
+'use strict'
 
-const bcrypt = require('bcrypt');
-const Sequelize = require('sequelize');
-const db = require('../../db');
-const Review = require('./review');
+const bcrypt = require('bcrypt')
+const Sequelize = require('sequelize')
+const db = require('../../db')
+const Review = require('./review')
 
 const Product = db.define('products', {
   name: {
     type: Sequelize.STRING,
     allowNull: false,
     validate: {
-      notEmpty: true
+      notEmpty: true,
       // TODO: Enforce unique names for products
-    }
+    },
   },
   description: {
     type: Sequelize.TEXT,
     allowNull: false,
     validate: {
-      notEmpty: true
-    }
+      notEmpty: true,
+    },
   },
   price: {
     type: Sequelize.DECIMAL(16, 2),
     allowNull: false,
     validate: {
-      notEmpty: true
-    }
+      notEmpty: true,
+    },
   },
-  quantity: { // This is the remaining product inventory
+  quantity: {
+    // This is the remaining product inventory
     type: Sequelize.INTEGER,
     allowNull: false,
     validate: {
       notEmpty: true,
-      min: 0
-    }
+      min: 0,
+    },
   },
   photo: {
     type: Sequelize.STRING,
   },
-  categories: Sequelize.ARRAY(Sequelize.STRING)
-});
+  categories: Sequelize.ARRAY(Sequelize.STRING),
+})
 
-module.exports = Product;
+module.exports = Product

--- a/db/models/product.test.js
+++ b/db/models/product.test.js
@@ -2,22 +2,21 @@
 
 const db = require('../../db')
 const Product = require('./product')
-const {expect} = require('chai')
+const { expect } = require('chai')
 
 describe('Product', () => {
   before('wait for the db', () => db.didSync)
 
-  let testCookie;
+  let testCookie
   before('make test cookie', () => {
     return Product.create({
-            name: 'Chocolate Chip',
-            description: 'The classic. Enjoy with a tall glass of cold milk.',
-            price: '1.50',
-            quantity: 250,
-            photo: 'images/cookies/chocolate-chip.jpg',
-            categories: ['chocolate', 'classic']
-          })
-          .then(result => testCookie = result)
+      name: 'Chocolate Chip',
+      description: 'The classic. Enjoy with a tall glass of cold milk.',
+      price: '1.50',
+      quantity: 250,
+      photo: 'images/cookies/chocolate-chip.jpg',
+      categories: ['chocolate', 'classic'],
+    }).then(result => (testCookie = result))
   })
 
   describe('check if cookie has been created', () => {

--- a/db/models/review.js
+++ b/db/models/review.js
@@ -5,28 +5,28 @@ const Sequelize = require('sequelize')
 const db = require('../../db')
 
 const Review = db.define('reviews', {
-	title: {
-		type: Sequelize.STRING,
-		allowNull: false
-	},
-	body: {
-		type: Sequelize.TEXT
-	},
-	rating: {
-		type: Sequelize.INTEGER,
-		allowNull: false,
-		validate: {
-			notEmpty: true,
-			min: 1,
-			max: 5
-		}
-	},
-	photo: {
-		type: Sequelize.STRING,
-		validate: {
-			isUrl: true
-		}
-	}
-});
+  title: {
+    type: Sequelize.STRING,
+    allowNull: false,
+  },
+  body: {
+    type: Sequelize.TEXT,
+  },
+  rating: {
+    type: Sequelize.INTEGER,
+    allowNull: false,
+    validate: {
+      notEmpty: true,
+      min: 1,
+      max: 5,
+    },
+  },
+  photo: {
+    type: Sequelize.STRING,
+    validate: {
+      isUrl: true,
+    },
+  },
+})
 
-module.exports = Review;
+module.exports = Review

--- a/db/models/review.test.js
+++ b/db/models/review.test.js
@@ -1,23 +1,26 @@
-'use strict';
+'use strict'
 
-const Sequelize = require('sequelize');
-const db = require('../../db');
-const Review = require('./user');
-const { expect } = require('chai');
+const Sequelize = require('sequelize')
+const db = require('../../db')
+const Review = require('./user')
+const { expect } = require('chai')
 
 describe('Review', () => {
-  before('wait for the db', () => db.didSync);
-
+  before('wait for the db', () => db.didSync)
 
   // Some feedback on how best to test this type of functionality would be much appreciated -evan
   describe('Persistence to the db', () => {
     xit('Does not allow a title to be null', () =>
-      Review.create({ title: null, body: 'oops!', rating: 3, photo: 'http://www.yahoo.com/donald_trump_golden_shower.jpg' })
-      .then(result => console.log(result)));
+      Review.create({
+        title: null,
+        body: 'oops!',
+        rating: 3,
+        photo: 'http://www.yahoo.com/donald_trump_golden_shower.jpg',
+      }).then(result => console.log(result)))
 
     // it('', () =>
     //   Review.create({ name: 'dude', password: 'ok' })
     //   .then(user => user.authenticate('not ok'))
     //   .then(result => expect(result).to.be.false));
-  });
-});
+  })
+})

--- a/db/models/user.js
+++ b/db/models/user.js
@@ -1,77 +1,80 @@
-'use strict';
+'use strict'
 
-const bcrypt = require('bcrypt');
-const Sequelize = require('sequelize');
-const db = require('../../db');
+const bcrypt = require('bcrypt')
+const Sequelize = require('sequelize')
+const db = require('../../db')
 
-const Review = require('./review');
+const Review = require('./review')
 // const Order = require('./order');
 
+const User = db.define(
+  'users',
+  {
+    name: {
+      type: Sequelize.STRING,
+      allowNull: false,
+    },
+    email: {
+      type: Sequelize.STRING,
+      validate: {
+        isEmail: true,
+        notEmpty: true,
+      },
+    },
+    billingAddress: Sequelize.STRING,
+    billingCity: Sequelize.STRING,
+    billingState: Sequelize.STRING,
+    billingZip: Sequelize.INTEGER,
 
-const User = db.define('users', {
-  name: {
-    type: Sequelize.STRING,
-    allowNull: false
+    shippingAddress: Sequelize.STRING,
+    shippingCity: Sequelize.STRING,
+    shippingState: Sequelize.STRING,
+    shippingZip: Sequelize.INTEGER,
+
+    // We support oauth, so users may or may not have passwords.
+    password_digest: Sequelize.STRING,
+    password: Sequelize.VIRTUAL,
+    resetPassword: Sequelize.BOOLEAN,
+
+    isAdmin: {
+      type: Sequelize.BOOLEAN,
+      defaultValue: false,
+      allowNull: false,
+    },
+    role: {
+      type: Sequelize.ENUM('unauth', 'auth'),
+      defaultValue: 'unauth',
+    },
   },
-  email: {
-    type: Sequelize.STRING,
-    validate: {
-      isEmail: true,
-      notEmpty: true
-    }
-  },
-  billingAddress: Sequelize.STRING,
-  billingCity: Sequelize.STRING,
-  billingState: Sequelize.STRING,
-  billingZip: Sequelize.INTEGER,
-
-  shippingAddress: Sequelize.STRING,
-  shippingCity: Sequelize.STRING,
-  shippingState: Sequelize.STRING,
-  shippingZip: Sequelize.INTEGER,
-
-  // We support oauth, so users may or may not have passwords.
-  password_digest: Sequelize.STRING,
-  password: Sequelize.VIRTUAL,
-  resetPassword: Sequelize.BOOLEAN,
-
-  isAdmin: {
-    type: Sequelize.BOOLEAN,
-    defaultValue: false,
-    allowNull: false
-  },
-  role: {
-    type: Sequelize.ENUM('unauth', 'auth'),
-    defaultValue: 'unauth'
+  {
+    indexes: [{ fields: ['email'], unique: true }],
+    hooks: {
+      beforeCreate: setEmailAndPassword,
+      beforeUpdate: setEmailAndPassword,
+    },
+    instanceMethods: {
+      authenticate(plaintext) {
+        return new Promise((resolve, reject) =>
+          bcrypt.compare(plaintext, this.password_digest, (err, result) =>
+            err ? reject(err) : resolve(result)
+          )
+        )
+      },
+    },
   }
-}, {
-  indexes: [{ fields: ['email'], unique: true }],
-  hooks: {
-    beforeCreate: setEmailAndPassword,
-    beforeUpdate: setEmailAndPassword
-  },
-  instanceMethods: {
-    authenticate(plaintext) {
-      return new Promise((resolve, reject) =>
-        bcrypt.compare(plaintext, this.password_digest,
-          (err, result) =>
-          err ? reject(err) : resolve(result))
-      );
-    }
-  }
-});
+)
 
 function setEmailAndPassword(user) {
-  user.email = user.email && user.email.toLowerCase();
-  if (!user.password) return Promise.resolve(user);
+  user.email = user.email && user.email.toLowerCase()
+  if (!user.password) return Promise.resolve(user)
 
   return new Promise((resolve, reject) =>
     bcrypt.hash(user.get('password'), 10, (err, hash) => {
-      if (err) reject(err);
-      user.set('password_digest', hash);
-      resolve(user);
+      if (err) reject(err)
+      user.set('password_digest', hash)
+      resolve(user)
     })
-  );
+  )
 }
 
-module.exports = User;
+module.exports = User

--- a/db/models/user.test.js
+++ b/db/models/user.test.js
@@ -2,7 +2,7 @@
 
 const db = require('../../db')
 const User = require('./user')
-const {expect} = require('chai')
+const { expect } = require('chai')
 
 describe('User', () => {
   before('wait for the db', () => db.didSync)

--- a/db/seed.js
+++ b/db/seed.js
@@ -1,35 +1,169 @@
 const db = require('../db')
 
-const seedUsers = () => db.Promise.map([
-  {name: 'Evan', email: 'evan@example.com', password: '1234', isAdmin: true},
-  {name: 'Sean', email: 'sean@example.com', password: '1234', isAdmin: true},
-  {name: 'Rachel', email: 'rachel@example.com', password: '1234', isAdmin: true},
-  {name: 'Test1', email: 'test1@example.com', password: '1234', isAdmin: false}
-], user => db.model('users').create(user))
+const seedUsers = () =>
+  db.Promise.map(
+    [
+      {
+        name: 'Evan',
+        email: 'evan@example.com',
+        password: '1234',
+        isAdmin: true,
+      },
+      {
+        name: 'Sean',
+        email: 'sean@example.com',
+        password: '1234',
+        isAdmin: true,
+      },
+      {
+        name: 'Rachel',
+        email: 'rachel@example.com',
+        password: '1234',
+        isAdmin: true,
+      },
+      {
+        name: 'Test1',
+        email: 'test1@example.com',
+        password: '1234',
+        isAdmin: false,
+      },
+    ],
+    user => db.model('users').create(user)
+  )
 
-const seedProducts = () => db.Promise.map([
-  {name: 'Chocolate Chip', description: 'The classic. Enjoy with a tall glass of cold milk.', price: '1.50', quantity: 250, photo: 'images/cookies/chocolate-chip.jpg', categories: ['chocolate', 'classic']},
-  {name: 'Chocolate Chip with Walnuts', description: 'Brain food. Healthy!', price: '1.50', quantity: 250, photo: 'images/cookies/chocolate-chip-walnut.jpg', categories: ['chocolate', 'nuts']},
-  {name: 'Oatmeal Raisin', description: 'Why would you order this? Really?', price: '1.50', quantity: 250, photo: 'images/cookies/oatmeal-raisin.jpg', categories: ['oatmeal', 'classic']},
-  {name: 'Oatmeal Chocolate Chip', description: 'This is an improvement on oatmeal raisin.', price: '1.50', quantity: 250, photo: 'images/cookies/oatmeal-choc-chip.jpg', categories: ['chocolate', 'classic', 'oatmeal']},
-  {name: 'Sugar Cookie with Frosting & Sprinkles', description: "It's festive and fun.", price: '1.50', quantity: 250, photo: 'images/cookies/sugar-cookie-frosting-sprinkles.jpg', categories: ['sugar', 'classic', 'holiday']},
-  {name: 'Snickerdoodle', description: 'Sugar cookies with cinnamon. Enjoy with high tea.', price: '1.50', quantity: 250, photo: 'images/cookies/snickerdoodle.jpg', categories: ['classic']},
-  {name: 'White Chocolate & Macadamia Nut', description: "Maximum sweetness.", price: '1.50', quantity: 250, photo: 'images/cookies/white-choc-macadamia-nut.jpg', categories: ['white chocolate', 'nuts']},
-  {name: 'Gingerbread', description: 'Great all year round!', price: '1.50', quantity: 250, photo: 'images/cookies/gingerbread-man.jpg', categories: ['holiday', 'classic']},
-  {name: 'Salted Caramel Chocolate Chip Cookie', description: 'For the hipsters out there.', price: '1.50', quantity: 250, photo: 'images/cookies/salted-caramel-choc-chip.jpg', categories: ['hipster', 'caramel', 'chocolate']},
-  {name: 'Black & White Cookie', description: 'The race relations cookie made famous by Jerry Seinfeld.', price: '1.50', quantity: 250, photo: 'images/cookies/black-white.jpg', categories: ['classic']},
-  {name: 'Peanut Butter Cookie', description: 'Keeps you satisfied.', price: '1.50', quantity: 250, photo: 'images/cookies/peanut-butter.jpg', categories: ['classic', 'nut']},
-  {name: 'Lemon Raspberry Cookie', description: 'Made by award-winning baker Erica McBride.', price: '1.50', quantity: 250, photo: 'images/cookies/lemon-raspberry.jpg', categories: ['classic', 'regal', 'award-winning']}
-], product => db.model('products').create(product))
+const seedProducts = () =>
+  db.Promise.map(
+    [
+      {
+        name: 'Chocolate Chip',
+        description: 'The classic. Enjoy with a tall glass of cold milk.',
+        price: '1.50',
+        quantity: 250,
+        photo: 'images/cookies/chocolate-chip.jpg',
+        categories: ['chocolate', 'classic'],
+      },
+      {
+        name: 'Chocolate Chip with Walnuts',
+        description: 'Brain food. Healthy!',
+        price: '1.50',
+        quantity: 250,
+        photo: 'images/cookies/chocolate-chip-walnut.jpg',
+        categories: ['chocolate', 'nuts'],
+      },
+      {
+        name: 'Oatmeal Raisin',
+        description: 'Why would you order this? Really?',
+        price: '1.50',
+        quantity: 250,
+        photo: 'images/cookies/oatmeal-raisin.jpg',
+        categories: ['oatmeal', 'classic'],
+      },
+      {
+        name: 'Oatmeal Chocolate Chip',
+        description: 'This is an improvement on oatmeal raisin.',
+        price: '1.50',
+        quantity: 250,
+        photo: 'images/cookies/oatmeal-choc-chip.jpg',
+        categories: ['chocolate', 'classic', 'oatmeal'],
+      },
+      {
+        name: 'Sugar Cookie with Frosting & Sprinkles',
+        description: "It's festive and fun.",
+        price: '1.50',
+        quantity: 250,
+        photo: 'images/cookies/sugar-cookie-frosting-sprinkles.jpg',
+        categories: ['sugar', 'classic', 'holiday'],
+      },
+      {
+        name: 'Snickerdoodle',
+        description: 'Sugar cookies with cinnamon. Enjoy with high tea.',
+        price: '1.50',
+        quantity: 250,
+        photo: 'images/cookies/snickerdoodle.jpg',
+        categories: ['classic'],
+      },
+      {
+        name: 'White Chocolate & Macadamia Nut',
+        description: 'Maximum sweetness.',
+        price: '1.50',
+        quantity: 250,
+        photo: 'images/cookies/white-choc-macadamia-nut.jpg',
+        categories: ['white chocolate', 'nuts'],
+      },
+      {
+        name: 'Gingerbread',
+        description: 'Great all year round!',
+        price: '1.50',
+        quantity: 250,
+        photo: 'images/cookies/gingerbread-man.jpg',
+        categories: ['holiday', 'classic'],
+      },
+      {
+        name: 'Salted Caramel Chocolate Chip Cookie',
+        description: 'For the hipsters out there.',
+        price: '1.50',
+        quantity: 250,
+        photo: 'images/cookies/salted-caramel-choc-chip.jpg',
+        categories: ['hipster', 'caramel', 'chocolate'],
+      },
+      {
+        name: 'Black & White Cookie',
+        description: 'The race relations cookie made famous by Jerry Seinfeld.',
+        price: '1.50',
+        quantity: 250,
+        photo: 'images/cookies/black-white.jpg',
+        categories: ['classic'],
+      },
+      {
+        name: 'Peanut Butter Cookie',
+        description: 'Keeps you satisfied.',
+        price: '1.50',
+        quantity: 250,
+        photo: 'images/cookies/peanut-butter.jpg',
+        categories: ['classic', 'nut'],
+      },
+      {
+        name: 'Lemon Raspberry Cookie',
+        description: 'Made by award-winning baker Erica McBride.',
+        price: '1.50',
+        quantity: 250,
+        photo: 'images/cookies/lemon-raspberry.jpg',
+        categories: ['classic', 'regal', 'award-winning'],
+      },
+    ],
+    product => db.model('products').create(product)
+  )
 
-const seedReviews = () => db.Promise.map([
-  {title: 'Gross!', body: 'Will never order these again. Disgusting. Ruined the party.', rating: 1, user_id: 3, product_id: 4},
-  {title: 'Delicious!', body: 'Will order these constantly. Getting fat.', rating: 5, user_id: 3, product_id: 1},
-  {title: 'Meh', body: 'Not the worst.', rating: 3, user_id: 3, product_id: 9},
-], review => db.model('reviews').create(review))
+const seedReviews = () =>
+  db.Promise.map(
+    [
+      {
+        title: 'Gross!',
+        body: 'Will never order these again. Disgusting. Ruined the party.',
+        rating: 1,
+        user_id: 3,
+        product_id: 4,
+      },
+      {
+        title: 'Delicious!',
+        body: 'Will order these constantly. Getting fat.',
+        rating: 5,
+        user_id: 3,
+        product_id: 1,
+      },
+      {
+        title: 'Meh',
+        body: 'Not the worst.',
+        rating: 3,
+        user_id: 3,
+        product_id: 9,
+      },
+    ],
+    review => db.model('reviews').create(review)
+  )
 
 db.didSync
-  .then(() => db.sync({force: true}))
+  .then(() => db.sync({ force: true }))
   .then(seedUsers)
   .then(users => console.log(`Seeded ${users.length} users OK`))
   .then(seedProducts)

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {resolve} = require('path')
+const { resolve } = require('path')
 const chalk = require('chalk')
 const pkg = require('./package.json')
 const debug = require('debug')(`${pkg.name}:boot`)
@@ -11,8 +11,8 @@ const debug = require('debug')(`${pkg.name}:boot`)
 //   or ~/.your_app_name.env.json
 //
 // and add it to the environment.
-const env = Object.create(process.env)
-  , secretsFile = resolve(env.HOME, `.${pkg.name}.env`)
+const env = Object.create(process.env),
+  secretsFile = resolve(env.HOME, `.${pkg.name}.env`)
 try {
   Object.assign(env, require(secretsFile))
 } catch (error) {
@@ -21,8 +21,12 @@ try {
 }
 
 module.exports = {
-  get name() { return pkg.name },
-  get isTesting() { return !!global.it },
+  get name() {
+    return pkg.name
+  },
+  get isTesting() {
+    return !!global.it
+  },
   get isProduction() {
     return process.env.NODE_ENV === 'production'
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,15 +4,311 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+          "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true
+    },
+    "@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true
+    },
+    "@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.29.7"
+      }
+    },
     "@babel/runtime": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="
     },
+    "@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      }
+    },
+    "@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+          "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+          "dev": true
+        }
+      }
+    },
+    "@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true
+    },
+    "@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "globals": {
+          "version": "13.24.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+          "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
+    },
+    "@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
+    },
+    "@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "dev": true
+    },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
     "@types/geojson": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.6.tgz",
       "integrity": "sha512-Xqg/lIZMrUd0VRmSRbCAewtwGZiAk3mEUDvV4op1tGl+LvyPcb/MIOSxTl9z+9+J+R4/vpjiCAT4xeKzH9ji1w=="
+    },
+    "@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "dev": true
     },
     "accepts": {
       "version": "1.3.8",
@@ -28,6 +324,24 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
       "integrity": "sha512-OLUyIIZ7mF5oaAUT1w0TFqQS81q3saT46x8t7ukpPjMNk+nbs4ZHhs7ToV8EWnLYLepjETXd4XaCE4uxkMeqUw==",
       "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
     },
     "align-text": {
       "version": "0.1.4",
@@ -66,6 +380,12 @@
         "normalize-path": "^2.0.0"
       }
     },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
@@ -101,11 +421,78 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
+    "array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      }
+    },
     "array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg==",
       "dev": true
+    },
+    "array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      }
+    },
+    "array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      }
+    },
+    "array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      }
+    },
+    "array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      }
     },
     "arraybuffer.prototype.slice": {
       "version": "1.0.4",
@@ -245,6 +632,20 @@
         "private": "^0.1.8",
         "slash": "^1.0.0",
         "source-map": "^0.5.7"
+      }
+    },
+    "babel-eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
       }
     },
     "babel-generator": {
@@ -1255,6 +1656,12 @@
         "get-intrinsic": "^1.3.0"
       }
     },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
     "camelcase": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -1618,6 +2025,17 @@
         "object-assign": "^4.1.1"
       }
     },
+    "cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
     "crypto-browserify": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz",
@@ -1718,6 +2136,12 @@
         }
       }
     },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
     "define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -1790,6 +2214,15 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
       "integrity": "sha512-597ykPFhtJYaXqPq6fF7Vl1fXTKgPdLOntyxpmdzUOKiYGqK7zcnbplj5088+8qJnWdzXhyeau5iVr8HVo9dgg==",
       "dev": true
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
     },
     "dom-helpers": {
       "version": "3.4.0",
@@ -2020,6 +2453,30 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
     },
+    "es-iterator-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
+      "integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0"
+      }
+    },
     "es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -2036,6 +2493,15 @@
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      }
+    },
+    "es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "requires": {
         "hasown": "^2.0.2"
       }
     },
@@ -2058,6 +2524,316 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+    },
+    "eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "dev": true,
+      "requires": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "eslint-visitor-keys": {
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+          "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.3"
+          }
+        },
+        "globals": {
+          "version": "13.24.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+          "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.2.tgz",
+      "integrity": "sha512-/IGJ6+Dka158JnP5n5YFMOszjDWrXggGz1LaK/guZq9vZTmniaKlHcsscvkAhn9y4U+BU3JuUdYvtAMcv30y4A==",
+      "dev": true
+    },
+    "eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "resolve": {
+          "version": "2.0.0-next.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+          "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+          "dev": true,
+          "requires": {
+            "es-errors": "^1.3.0",
+            "is-core-module": "^2.16.2",
+            "node-exports-info": "^1.6.0",
+            "object-keys": "^1.1.1",
+            "path-parse": "^1.0.7",
+            "supports-preserve-symlinks-flag": "^1.0.0"
+          }
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.16.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+          "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+          "dev": true
+        },
+        "eslint-visitor-keys": {
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+          "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+          "dev": true
+        }
+      }
+    },
+    "esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      }
+    },
+    "estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
@@ -2174,6 +2950,33 @@
         "is-extglob": "^1.0.0"
       }
     },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
+    "fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
     "fbjs": {
       "version": "0.8.18",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.18.tgz",
@@ -2193,6 +2996,15 @@
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA=="
         }
+      }
+    },
+    "file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^3.0.4"
       }
     },
     "file-uri-to-path": {
@@ -2270,6 +3082,23 @@
         "path-exists": "^2.0.0",
         "pinkie-promise": "^2.0.0"
       }
+    },
+    "flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "requires": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true
     },
     "follow-redirects": {
       "version": "1.0.0",
@@ -2491,6 +3320,12 @@
       "integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
       "dev": true
     },
+    "graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true
+    },
     "growl": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
@@ -2705,6 +3540,28 @@
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true
     },
+    "ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true
+    },
     "indexof": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
@@ -2837,6 +3694,15 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
     },
+    "is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "requires": {
+        "hasown": "^2.0.3"
+      }
+    },
     "is-data-descriptor": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.1.tgz",
@@ -2965,6 +3831,12 @@
         "has-tostringtag": "^1.0.2"
       }
     },
+    "is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true
+    },
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -3089,6 +3961,12 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -3103,6 +3981,20 @@
         "whatwg-fetch": ">=0.10.0"
       }
     },
+    "iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "requires": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      }
+    },
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -3113,10 +4005,37 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg=="
     },
+    "js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
     "jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha512-Mke0DA0QjUWuJlhsE0ZPPhYiJkRap642SmI/4ztCFaUs6V2AiH1sfecc+57NgaryfAA2VR3v6O+CSjC1jZJKOA==",
+      "dev": true
+    },
+    "json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
     "json3": {
@@ -3131,6 +4050,18 @@
       "integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
       "dev": true
     },
+    "jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      }
+    },
     "keycode": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
@@ -3142,6 +4073,15 @@
       "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
       "requires": {
         "tsscmp": "1.0.6"
+      }
+    },
+    "keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.1"
       }
     },
     "kind-of": {
@@ -3158,6 +4098,16 @@
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==",
       "dev": true
+    },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
     },
     "libpq": {
       "version": "1.11.0",
@@ -3193,6 +4143,15 @@
         "emojis-list": "^2.0.0",
         "json5": "^0.5.0",
         "object-assign": "^4.0.1"
+      }
+    },
+    "locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^5.0.0"
       }
     },
     "lodash": {
@@ -3603,10 +4562,28 @@
         }
       }
     },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
     "negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "node-exports-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "dev": true,
+      "requires": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      }
     },
     "node-fetch": {
       "version": "1.7.3",
@@ -3772,6 +4749,18 @@
         "es-object-atoms": "^1.1.1"
       }
     },
+    "object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      }
+    },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
@@ -3842,6 +4831,20 @@
         }
       }
     },
+    "optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      }
+    },
     "os-browserify": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
@@ -3870,6 +4873,24 @@
         "safe-push-apply": "^1.0.0"
       }
     },
+    "p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "requires": {
+        "yocto-queue": "^0.1.0"
+      }
+    },
+    "p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^3.0.2"
+      }
+    },
     "packet-reader": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.3.1.tgz",
@@ -3880,6 +4901,15 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
       "dev": true
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
     },
     "parse-glob": {
       "version": "3.0.4",
@@ -4017,6 +5047,18 @@
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true
     },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
     "path-to-regexp": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
@@ -4144,6 +5186,12 @@
         "split2": "^4.1.0"
       }
     },
+    "picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
@@ -4202,10 +5250,22 @@
         "xtend": "^4.0.0"
       }
     },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha512-s/46sYeylUfHNjI+sA/78FAHlmIuKqI9wNnzEOGehAlUUYeObv5C2mOinXBjyUyWmJ2SfcS2/ydApH4hTF4WXQ==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
     },
     "private": {
@@ -4835,6 +5895,24 @@
         "is-finite": "^1.0.0"
       }
     },
+    "resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "requires": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -4856,6 +5934,12 @@
         "debug": "^2.6.9"
       }
     },
+    "reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true
+    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -4863,6 +5947,31 @@
       "dev": true,
       "requires": {
         "align-text": "^0.1.1"
+      }
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "ripemd160": {
@@ -5097,6 +6206,21 @@
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz",
       "integrity": "sha512-GC+qN4sf/O6bDwz6CHaz8HVQfLbbNyIsXpTZLiD5c1badnWA63WVAH1msoCq+fXcV0dZ50jxTqKA8seu40845A==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
     "shimmer": {
@@ -5372,6 +6496,37 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ=="
     },
+    "string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      }
+    },
+    "string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
     "string.prototype.trim": {
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
@@ -5432,6 +6587,12 @@
         "ansi-regex": "^2.0.0"
       }
     },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
     "superagent": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-2.3.0.tgz",
@@ -5475,6 +6636,12 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g=="
     },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
+    },
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
@@ -5502,6 +6669,12 @@
         "@types/geojson": "^1.0.0",
         "terraformer": "~1.0.5"
       }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
     },
     "timers-browserify": {
       "version": "2.0.12",
@@ -5602,10 +6775,25 @@
       "integrity": "sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==",
       "dev": true
     },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
     "type-detect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
       "integrity": "sha512-f9Uv6ezcpvCQjJU0Zqbg+65qdcszv3qUQsZfjdRbWiZ7AMenrX1u0lNk9EoWWX6e1F+NULyg27mtdeZ5WhpljA==",
+      "dev": true
+    },
+    "type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
     },
     "type-is": {
@@ -5794,6 +6982,23 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
+          "dev": true
+        }
+      }
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+          "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
           "dev": true
         }
       }
@@ -6016,6 +7221,15 @@
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="
     },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
     "which-boxed-primitive": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
@@ -6091,6 +7305,12 @@
       "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.2.0.tgz",
       "integrity": "sha512-iWvzgpYGCoUVCb7IE7wy3MiG52gwEmv9QPomiovZ+UgqjYytZ6LjNS8VabPZpGQGu4RXppGaMrauFuz3mKfMjg=="
     },
+    "word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true
+    },
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -6119,6 +7339,12 @@
         "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,11 @@
     "start[prod]": "check-node-version --node '>= 10.15.3' && node server/start.js",
     "start": "check-node-version --node '>= 10.15.3' && npm run start[prod]",
     "seed": "node db/seed.js",
-    "postinstall": "npm run build && node db/seed.js"
+    "postinstall": "npm run build && node db/seed.js",
+    "lint": "eslint app/ server/ db/ index.js",
+    "lint:fix": "eslint --fix app/ server/ db/ index.js",
+    "format": "prettier --write app/ server/ db/ index.js",
+    "format:check": "prettier --check app/ server/ db/ index.js"
   },
   "repository": {
     "type": "git",
@@ -73,7 +77,11 @@
     "babel-register": "^6.18.0",
     "chai": "^3.5.0",
     "debug": "^2.6.0",
+    "eslint": "^8.57.1",
+    "eslint-config-prettier": "^8.10.2",
+    "eslint-plugin-react": "^7.37.5",
     "mocha": "^3.1.2",
+    "prettier": "^2.8.8",
     "react-addons-test-utils": "^15.4.2",
     "supertest": "^2.0.1",
     "supertest-as-promised": "^4.0.1",

--- a/server/api.js
+++ b/server/api.js
@@ -1,10 +1,10 @@
 'use strict'
 
 const db = require('../db')
-const api = module.exports = require('express').Router()
+const api = (module.exports = require('express').Router())
 
 api
-  .get('/heartbeat', (req, res) => res.send({ok: true,}))
+  .get('/heartbeat', (req, res) => res.send({ ok: true }))
   .use('/auth', require('./auth'))
   .use('/users', require('./users'))
   .use('/products', require('./products'))
@@ -13,7 +13,7 @@ api
 
 // Send along any errors AND LOG OUT TO SERVER
 api.use((err, req, res, next) => {
-  console.log(err);
+  console.log(err)
   res.status(500).send(err)
 })
 

--- a/server/auth.filters.js
+++ b/server/auth.filters.js
@@ -13,8 +13,8 @@ const selfOnly = action => (req, res, next) => {
 }
 
 const forbidden = message => (req, res, next) => {
-  console.log("running forbidden");
-  return res.status(403).send(message);
+  console.log('running forbidden')
+  return res.status(403).send(message)
 }
 
 // const selfOnlyOrAdmin = action => (req, res, next) => {
@@ -24,5 +24,4 @@ const forbidden = message => (req, res, next) => {
 //   next()
 // }
 
-
-module.exports = {mustBeLoggedIn, selfOnly, forbidden}
+module.exports = { mustBeLoggedIn, selfOnly, forbidden }

--- a/server/auth.js
+++ b/server/auth.js
@@ -1,11 +1,11 @@
-const app = require('../index.js'), {env} = app
+const app = require('../index.js'),
+  { env } = app
 const debug = require('debug')(`${app.name}:auth`)
 const passport = require('passport')
 
 const User = require('../db/models/user')
 const OAuth = require('../db/models/oauth')
 const auth = require('express').Router()
-
 
 /*************************
  * Auth strategies
@@ -43,7 +43,7 @@ OAuth.setupStrategy({
     clientSecret: env.FACEBOOK_CLIENT_SECRET,
     callbackURL: `${app.rootUrl}/api/auth/login/facebook`,
   },
-  passport
+  passport,
 })
 
 // Google needs the GOOGLE_CONSUMER_SECRET AND GOOGLE_CONSUMER_KEY
@@ -56,7 +56,7 @@ OAuth.setupStrategy({
     consumerSecret: env.GOOGLE_CONSUMER_SECRET,
     callbackURL: `${app.rootUrl}/api/auth/login/google`,
   },
-  passport
+  passport,
 })
 
 // Github needs the GITHUB_CLIENT_ID AND GITHUB_CLIENT_SECRET
@@ -69,7 +69,7 @@ OAuth.setupStrategy({
     clientSecrets: env.GITHUB_CLIENT_SECRET,
     callbackURL: `${app.rootUrl}/api/auth/login/github`,
   },
-  passport
+  passport,
 })
 
 // Other passport configuration:
@@ -80,49 +80,46 @@ passport.serializeUser((user, done) => {
   debug('did serialize user.id=%d', user.id)
 })
 
-passport.deserializeUser(
-  (id, done) => {
-    debug('will deserialize user.id=%d', id)
-    User.findById(id)
-      .then(user => {
-        debug('deserialize did ok user.id=%d', user.id)
-        done(null, user)
-      })
-      .catch(err => {
-        debug('deserialize did fail err=%s', err)
-        done(err)
-      })
-  }
-)
+passport.deserializeUser((id, done) => {
+  debug('will deserialize user.id=%d', id)
+  User.findById(id)
+    .then(user => {
+      debug('deserialize did ok user.id=%d', user.id)
+      done(null, user)
+    })
+    .catch(err => {
+      debug('deserialize did fail err=%s', err)
+      done(err)
+    })
+})
 
-passport.use(new (require('passport-local').Strategy) (
-  (email, password, done) => {
+passport.use(
+  new (require('passport-local').Strategy)((email, password, done) => {
     debug('will authenticate user(email: "%s")', email)
-    User.findOne({where: {email}})
+    User.findOne({ where: { email } })
       .then(user => {
         if (!user) {
           debug('authenticate user(email: "%s") did fail: no such user', email)
           return done(null, false, { message: 'Login incorrect' })
         }
-        return user.authenticate(password)
-          .then(ok => {
-            if (!ok) {
-              debug('authenticate user(email: "%s") did fail: bad password')
-              return done(null, false, { message: 'Login incorrect' })
-            }
-            debug('authenticate user(email: "%s") did ok: user.id=%d', user.id)
-            done(null, user)
-          })
+        return user.authenticate(password).then(ok => {
+          if (!ok) {
+            debug('authenticate user(email: "%s") did fail: bad password')
+            return done(null, false, { message: 'Login incorrect' })
+          }
+          debug('authenticate user(email: "%s") did ok: user.id=%d', user.id)
+          done(null, user)
+        })
       })
       .catch(done)
-  }
-))
+  })
+)
 
 auth.get('/whoami', (req, res) => res.send(req.user))
 
 auth.post('/:strategy/login', (req, res, next) =>
   passport.authenticate(req.params.strategy, {
-    successRedirect: '/'
+    successRedirect: '/',
   })(req, res, next)
 )
 
@@ -132,4 +129,3 @@ auth.post('/logout', (req, res, next) => {
 })
 
 module.exports = auth
-

--- a/server/auth.test.js
+++ b/server/auth.test.js
@@ -1,5 +1,5 @@
 const request = require('supertest-as-promised')
-const {expect} = require('chai')
+const { expect } = require('chai')
 const db = require('../db')
 const User = require('../db/models/user')
 const app = require('./start')
@@ -7,19 +7,18 @@ const app = require('./start')
 const alice = {
   name: 'Alice Malice',
   username: 'alice@secrets.org',
-  password: '12345'
+  password: '12345',
 }
 
 describe('/api/auth', () => {
   before('create a user', () =>
-    db.didSync
-      .then(() =>
-        User.create(
-          {name: alice.name,
-            email: alice.username,
-          password: alice.password
-        })
-      )
+    db.didSync.then(() =>
+      User.create({
+        name: alice.name,
+        email: alice.username,
+        password: alice.password,
+      })
+    )
   )
 
   describe('POST /local/login (username, password)', () => {
@@ -29,57 +28,54 @@ describe('/api/auth', () => {
         .send(alice)
         .expect(302)
         .expect('Set-Cookie', /session=.*/)
-        .expect('Location', '/')
-      )
+        .expect('Location', '/'))
 
     it('fails with an invalid username and password', () =>
       request(app)
         .post('/api/auth/local/login')
-        .send({username: alice.username, password: 'wrong'})
-        .expect(401)
-      )
+        .send({ username: alice.username, password: 'wrong' })
+        .expect(401))
   })
 
   describe('GET /whoami', () => {
     describe('when logged in,', () => {
       const agent = request.agent(app)
-      before('log in', () => agent
-        .post('/api/auth/local/login')
-        .send(alice))
+      before('log in', () => agent.post('/api/auth/local/login').send(alice))
 
       it('responds with the currently logged in user', () =>
-        agent.get('/api/auth/whoami')
+        agent
+          .get('/api/auth/whoami')
           .set('Accept', 'application/json')
           .expect(200)
-          .then(res => expect(res.body).to.contain({
-            email: alice.username
-          }))
-      )
+          .then(res =>
+            expect(res.body).to.contain({
+              email: alice.username,
+            })
+          ))
     })
 
     it('when not logged in, responds with an empty object', () =>
-      request(app).get('/api/auth/whoami')
+      request(app)
+        .get('/api/auth/whoami')
         .expect(200)
-        .then(res => expect(res.body).to.eql({}))
-    )
+        .then(res => expect(res.body).to.eql({})))
   })
 
   describe('POST /logout when logged in', () => {
     const agent = request.agent(app)
 
-    before('log in', () => agent
-      .post('/api/auth/local/login')
-      .send(alice))
+    before('log in', () => agent.post('/api/auth/local/login').send(alice))
 
-    it('logs you out and redirects to whoami', () => agent
-      .post('/api/auth/logout')
-      .expect(302)
-      .expect('Location', '/api/auth/whoami')
-      .then(() =>
-        agent.get('/api/auth/whoami')
-          .expect(200)
-          .then(rsp => expect(rsp.body).eql({}))
-      )
-    )
+    it('logs you out and redirects to whoami', () =>
+      agent
+        .post('/api/auth/logout')
+        .expect(302)
+        .expect('Location', '/api/auth/whoami')
+        .then(() =>
+          agent
+            .get('/api/auth/whoami')
+            .expect(200)
+            .then(rsp => expect(rsp.body).eql({}))
+        ))
   })
 })

--- a/server/orders.js
+++ b/server/orders.js
@@ -4,333 +4,366 @@ const db = require('../db')
 const Order = require('../db/models/order')
 const Product = require('../db/models/product')
 const User = require('../db/models/user')
-const Promise = require('bluebird');
-const {mustBeLoggedIn, selfOnly, forbidden} = require('./auth.filters.js');
+const Promise = require('bluebird')
+const { mustBeLoggedIn, selfOnly, forbidden } = require('./auth.filters.js')
 
-module.exports = require('express').Router()
+module.exports = require('express')
+  .Router()
 
-	// Action: Retrieve all orders, including products and orderlineitem details
-	// Roles: Admin
-	.get('/', (req, res, next) => {
-		console.log("get /api/orders/");
-		// .get('/', mustBeLoggedIn, (req, res, next) => {
-		if (req.user && req.user.isAdmin) {
-			console.log("is an admin");
-			return Order.findAll({
-				include: [{
-					model: Product,
-					through: {
-						attributes: ['quantity', 'price']
-					}
-				}]
-			})
-				.then(orders => _promisifyOrderProps(orders))
-				.then(orders => Promise.all(orders))
-				.then(orders => res.json(orders))
-				.catch(next)
-		}
-		// If not an admin, retrieve your own orders
-		else if (req.user) {
-			console.log("else if req.user");
-			req.user.getOrders({
-				include: [{
-					model: Product,
-					through: {
-						attributes: ['quantity', 'price']
-					}
-				}]
-			})
-				.then(orders => _promisifyOrderProps(orders))
-				.then(orders => Promise.all(orders))
-				.then(orders => res.status(200).json(orders))
-				.catch(next)
-		} else {
-			// TEMP to test
-			return Order.findAll({
-				include: [{
-					model: Product,
-					through: {
-						attributes: ['quantity', 'price']
-					}
-				}]
-			})
-				.then(orders => _promisifyOrderProps(orders))
-				.then(orders => Promise.all(orders))
-				.then(orders => res.json(orders))
-				.catch(next)
-			// res.status(403).send("Cannot view without req.user");
+  // Action: Retrieve all orders, including products and orderlineitem details
+  // Roles: Admin
+  .get('/', (req, res, next) => {
+    console.log('get /api/orders/')
+    // .get('/', mustBeLoggedIn, (req, res, next) => {
+    if (req.user && req.user.isAdmin) {
+      console.log('is an admin')
+      return Order.findAll({
+        include: [
+          {
+            model: Product,
+            through: {
+              attributes: ['quantity', 'price'],
+            },
+          },
+        ],
+      })
+        .then(orders => _promisifyOrderProps(orders))
+        .then(orders => Promise.all(orders))
+        .then(orders => res.json(orders))
+        .catch(next)
+    }
+    // If not an admin, retrieve your own orders
+    else if (req.user) {
+      console.log('else if req.user')
+      req.user
+        .getOrders({
+          include: [
+            {
+              model: Product,
+              through: {
+                attributes: ['quantity', 'price'],
+              },
+            },
+          ],
+        })
+        .then(orders => _promisifyOrderProps(orders))
+        .then(orders => Promise.all(orders))
+        .then(orders => res.status(200).json(orders))
+        .catch(next)
+    } else {
+      // TEMP to test
+      return Order.findAll({
+        include: [
+          {
+            model: Product,
+            through: {
+              attributes: ['quantity', 'price'],
+            },
+          },
+        ],
+      })
+        .then(orders => _promisifyOrderProps(orders))
+        .then(orders => Promise.all(orders))
+        .then(orders => res.json(orders))
+        .catch(next)
+      // res.status(403).send("Cannot view without req.user");
+    }
+  })
 
-		}
-	})
+  // Action: Create a new order
+  // Roles: Guest, User, Admin
+  // Notes: The behavior of this action differs slightly
+  //   based on the role of the user. If the user is a
+  //   guest, they create an order unassociated with
+  //   any single user
+  //   User has actually ordered.
 
-	// Action: Create a new order
-	// Roles: Guest, User, Admin
-	// Notes: The behavior of this action differs slightly
-	//   based on the role of the user. If the user is a
-	//   guest, they create an order unassociated with
-	//   any single user
-	//   User has actually ordered.
+  .post('/:userId?', (req, res, next) => {
+    let order
+    let orderLineItems =
+      req.body && req.body.orderLineItems ? req.body.orderLineItems : null
+    let productIds = orderLineItems ? Object.keys(orderLineItems) : []
+    console.log('-------------------', req.param.userId)
 
-	.post('/:userId?', (req, res, next) => {
-		let order;
-		let orderLineItems = (req.body && req.body.orderLineItems) ? req.body.orderLineItems : null;
-		let productIds = (orderLineItems) ? Object.keys(orderLineItems) : [];
-		console.log("-------------------", req.param.userId);
+    // if the user is an admin
+    if (req.user && req.user.isAdmin) {
+      console.log('User is an admin')
+      // ...and the admin specifies a userID for whom to create an order
+      if (req.param && req.param.userId) {
+        console.log('User ', req.param.userId, ' specified as param')
+        User.findById(req.param.userId)
+          .then(user => user.createOrder(req.body)) // filter out only the Order attributes???
+          .then(_order => {
+            order = _order
+            return Promise.all(
+              productIds.map(productId => Product.findById(productId))
+            )
+          })
+          .then(products => {
+            if (products) {
+              products.forEach(product =>
+                order.addProduct(product, {
+                  quantity: orderLineItems[product.id].quantity,
+                  price: product.price,
+                })
+              )
+            }
+          })
+          .then(res.sendStatus(200))
+          .catch(next)
+      }
+      // ... and the user does not specify a userID
+      else {
+        console.log('No user specified as param')
+        Order.create(req.body)
+          .then(_order => {
+            order = _order
+            return Promise.all(
+              productIds.map(productId => Product.findById(productId))
+            )
+          })
+          .then(products => {
+            if (products) {
+              products.forEach(product =>
+                order.addProduct(product, {
+                  quantity: orderLineItems[product.id].quantity,
+                  price: product.price,
+                })
+              )
+            }
+          })
+          .then(() =>
+            Order.findById(order.id, {
+              include: [
+                {
+                  model: Product,
+                  through: {
+                    attributes: ['quantity', 'price'],
+                  },
+                },
+              ],
+            })
+          )
+          .then(order => {
+            return res.status(200).json(order)
+          })
+          .catch(next)
+      }
+    }
+    // ... and the user is not an admin
+    else if (req.user) {
+      console.log('user is not an admin')
+      req.user
+        .createOrder(req.body)
+        .then(_order => {
+          order = _order
+          return Promise.all(
+            productIds.map(productId => Product.findById(productId))
+          )
+        })
+        .then(products => {
+          if (products) {
+            return Promise.all(
+              products.map(product =>
+                order.addProduct(product, {
+                  quantity: orderLineItems[product.id].quantity,
+                  price: product.price,
+                })
+              )
+            )
+          }
+        })
+        .then(() =>
+          Order.findById(order.id, {
+            include: [
+              {
+                model: Product,
+                through: {
+                  attributes: ['quantity', 'price'],
+                },
+              },
+            ],
+          })
+        )
+        .then(order => {
+          console.log(order)
+          return res.status(200).json(order)
+        })
+        .catch(next)
+    }
+    // Guest User
+    else {
+      console.log('No user logged in so guest')
+      Order.create(req.body)
+        .then(_order => {
+          order = _order
+          return Promise.all(
+            productIds.map(productId => Product.findById(productId))
+          )
+        })
+        .then(products => {
+          if (products) {
+            products.forEach(product =>
+              order.addProduct(product, {
+                quantity: orderLineItems[product.id].quantity,
+                price: product.price,
+              })
+            )
+          }
+        })
+        .then(res.sendStatus(200))
+        .catch(next)
+    }
+  })
 
-		// if the user is an admin
-		if (req.user && req.user.isAdmin) {
-			console.log("User is an admin");
-			// ...and the admin specifies a userID for whom to create an order
-			if (req.param && req.param.userId) {
-				console.log("User ", req.param.userId, " specified as param");
-				User.findById(req.param.userId)
-					.then(user => user.createOrder(req.body)) // filter out only the Order attributes???
-					.then(_order => {
-						order = _order;
-						return Promise.all(productIds.map(productId => Product.findById(productId)))
-					})
-					.then(products => {
-						if (products) {
-							products.forEach((product) =>
-								order.addProduct(product, {
-									quantity: orderLineItems[product.id].quantity,
-									price: product.price
-								})
-							)
-						}
-					})
-					.then(res.sendStatus(200))
-					.catch(next)
-			}
-			// ... and the user does not specify a userID
-			else {
-				console.log("No user specified as param");
-				Order.create(req.body)
-					.then(_order => {
-						order = _order;
-						return Promise.all(productIds.map(productId => Product.findById(productId)))
-					})
-					.then(products => {
-						if (products) {
-							products.forEach((product) =>
-								order.addProduct(product, {
-									quantity: orderLineItems[product.id].quantity,
-									price: product.price
-								})
-							)
-						}
-					})
-					.then(() => Order.findById(order.id, {
-						include: [{
-							model: Product,
-							through: {
-								attributes: ['quantity', 'price']
-							}
-						}]
-					}))
-					.then(order => {
-						return res.status(200).json(order)
-					})
-					.catch(next)
-			}
-		}
-		// ... and the user is not an admin
-		else if (req.user) {
-			console.log('user is not an admin');
-			req.user.createOrder(req.body)
-				.then(_order => {
-					order = _order;
-					return Promise.all(productIds.map(productId => Product.findById(productId)))
-				})
-				.then(products => {
-					if (products) {
-						return Promise.all(
-							products.map((product) =>
-								order.addProduct(product, {
-									quantity: orderLineItems[product.id].quantity,
-									price: product.price
-								})
-							)
-						)
-					}
-				})
-				.then(() => Order.findById(order.id, {
-					include: [{
-						model: Product,
-						through: {
-							attributes: ['quantity', 'price']
-						}
-					}]
-				}))
-				.then(order => {
-					console.log(order);
-					return res.status(200).json(order)
-				})
-				.catch(next)
-		}
-		// Guest User
-		else {
-			console.log("No user logged in so guest");
-			Order.create(req.body)
-				.then(_order => {
-					order = _order;
-					return Promise.all(productIds.map(productId => Product.findById(productId)))
-				})
-				.then(products => {
-					if (products) {
-						products.forEach((product) =>
-							order.addProduct(product, {
-								quantity: orderLineItems[product.id].quantity,
-								price: product.price
-							})
-						)
-					}
-				})
-				.then(res.sendStatus(200))
-				.catch(next)
-		}
-	})
+  // TODO: Enhance to be able to create items at the same time once
+  //   Using this structure:
 
-	// TODO: Enhance to be able to create items at the same time once
-	//   Using this structure:
+  // "order": {
+  // 	"status": "cancelled",
+  //   "shippingRate": 9.99,
+  //   "shippingCarrier": null,
+  //   "trackingNumber": null,
+  // 	"orderLineItems": {
+  // 		"2": { "quantity": 10 },
+  // 		"10": { "quantity": 2 }
+  // 	}
+  // }
 
-	// "order": {
-	// 	"status": "cancelled",
-	//   "shippingRate": 9.99,
-	//   "shippingCarrier": null,
-	//   "trackingNumber": null,
-	// 	"orderLineItems": {
-	// 		"2": { "quantity": 10 },
-	// 		"10": { "quantity": 2 }
-	// 	}
-	// }
+  // This is a non-functional starting point
+  // .post('/', (req, res, next) =>
+  // 	Order.create(req.body, {
+  // 		include: [{
+  // 			model: Product,
+  // 			through: {
+  // 				attributes: ['quantity', 'price']
+  // 			}
+  // 		}]
+  // 	})
+  // 		.then((order) => { })
+  // 		.then(order => res.json(order))
+  // 		.catch(next))
 
-	// This is a non-functional starting point
-	// .post('/', (req, res, next) =>
-	// 	Order.create(req.body, {
-	// 		include: [{
-	// 			model: Product,
-	// 			through: {
-	// 				attributes: ['quantity', 'price']
-	// 			}
-	// 		}]
-	// 	})
-	// 		.then((order) => { })
-	// 		.then(order => res.json(order))
-	// 		.catch(next))
+  // Action: Retrieve a single order, including products and orderlineitem details
+  // Roles: Admin.
+  // Notes: Perhaps a user should be able to view this for their orders...
+  .get('/:id', mustBeLoggedIn, (req, res, next) => {
+    if (req.user.isAdmin) {
+      return Order.findById(req.params.id, {
+        include: [
+          {
+            model: Product,
+            through: {
+              attributes: ['quantity', 'price'],
+            },
+          },
+        ],
+      })
+        .then(orders => _promisifyOrderProps(orders))
+        .then(order => res.json(order))
+        .catch(next)
+    } else {
+      forbidden('You are not authorized to do this.')
+    }
+  })
 
-	// Action: Retrieve a single order, including products and orderlineitem details
-	// Roles: Admin.
-	// Notes: Perhaps a user should be able to view this for their orders...
-	.get('/:id', mustBeLoggedIn, (req, res, next) => {
-		if (req.user.isAdmin) {
-			return Order.findById(req.params.id, {
-				include: [{
-					model: Product,
-					through: {
-						attributes: ['quantity', 'price']
-					}
-				}]
-			}).then(orders => _promisifyOrderProps(orders))
-				.then(order => res.json(order))
-				.catch(next)
-		} else {
-			forbidden("You are not authorized to do this.");
-		}
-	})
+  // Action: Update an order
+  // Roles: Admin.
+  .put('/:id', mustBeLoggedIn, (req, res, next) => {
+    if (req.user.isAdmin) {
+      return Order.findById(req.params.id)
+        .then(order => order.update(req.body))
+        .then(order => res.status(200).json(order))
+        .catch(next)
+    } else {
+      forbidden('You are not authorized to do this.')
+    }
+  })
 
-	// Action: Update an order
-	// Roles: Admin.
-	.put('/:id', mustBeLoggedIn, (req, res, next) => {
-		if (req.user.isAdmin) {
-			return Order.findById(req.params.id)
-				.then(order => order.update(req.body))
-				.then(order => res.status(200).json(order))
-				.catch(next)
-		} else {
-			forbidden("You are not authorized to do this.");
-		}
-	})
+  // Action: Delete an order
+  // Roles: Admin.
+  .delete('/:id/', mustBeLoggedIn, (req, res, next) => {
+    if (req.user.isAdmin) {
+      return Order.findById(req.params.id)
+        .then(order => order.destroy())
+        .then(res.sendStatus(200))
+        .catch(next)
+    } else {
+      forbidden('You are not authorized to do this.')
+    }
+  })
 
-	// Action: Delete an order
-	// Roles: Admin.
-	.delete('/:id/', mustBeLoggedIn, (req, res, next) => {
-		if (req.user.isAdmin) {
-			return Order.findById(req.params.id)
-				.then(order => order.destroy())
-				.then(res.sendStatus(200))
-				.catch(next);
-		} else {
-			forbidden("You are not authorized to do this.");
-		}
-	})
+  // Action: Add several items to an order or update the item count in an order
+  // Roles: Admin.
+  // Example Request Body
+  // {"orderLineItems": {
+  // 	"2": {"quantity": 10},
+  //  	"10": {"quantity": 2}
+  // }}
+  .post('/:id/products/', mustBeLoggedIn, (req, res, next) => {
+    if (req.user.isAdmin) {
+      let orderLineItems = req.body.orderLineItems
+      let productIds = Object.keys(orderLineItems)
+      let order
+      Order.findById(req.params.id)
+        .then(_order => {
+          order = _order
+          return Promise.all(
+            productIds.map(productId => Product.findById(productId))
+          )
+        })
+        .then(products => {
+          products.forEach(product =>
+            order.addProduct(product, {
+              quantity: orderLineItems[product.id].quantity,
+              price: product.price,
+            })
+          )
+        })
+        .then(res.sendStatus(200))
+        .catch(next)
+    } else {
+      forbidden('You are not authorized to do this.')
+    }
+  })
 
-	// Action: Add several items to an order or update the item count in an order
-	// Roles: Admin.
-	// Example Request Body
-	// {"orderLineItems": {
-	// 	"2": {"quantity": 10},
-	//  	"10": {"quantity": 2}
-	// }}
-	.post('/:id/products/', mustBeLoggedIn, (req, res, next) => {
-		if (req.user.isAdmin) {
-			let orderLineItems = req.body.orderLineItems;
-			let productIds = Object.keys(orderLineItems);
-			let order;
-			Order.findById(req.params.id)
-				.then(_order => {
-					order = _order;
-					return Promise.all(productIds.map(productId => Product.findById(productId)))
-				})
-				.then(products => {
-					products.forEach((product) =>
-						order.addProduct(product, {
-							quantity: orderLineItems[product.id].quantity,
-							price: product.price
-						})
-					)
-				})
-				.then(res.sendStatus(200))
-				.catch(next)
-		} else {
-			forbidden("You are not authorized to do this.");
-		}
-	})
-
-	// Action: Remove an item from an order
-	// Roles: Admin.
-	.delete('/:orderId/products/:productId', mustBeLoggedIn, (req, res, next) => {
-		if (req.user.isAdmin) {
-			return Order.findById(req.params.orderId)
-				.then(order => order.removeProduct(req.params.productId))
-				.then(res.sendStatus(200))
-				.catch(next);
-		} else {
-			forbidden("You are not authorized to do this.");
-		}
-	})
+  // Action: Remove an item from an order
+  // Roles: Admin.
+  .delete('/:orderId/products/:productId', mustBeLoggedIn, (req, res, next) => {
+    if (req.user.isAdmin) {
+      return Order.findById(req.params.orderId)
+        .then(order => order.removeProduct(req.params.productId))
+        .then(res.sendStatus(200))
+        .catch(next)
+    } else {
+      forbidden('You are not authorized to do this.')
+    }
+  })
 
 // This is a kludgey looking helper function to deal with resolving a Promise
 // returned by a Sequelize getter
 // TODO : Clean up this nightmare somehow
 function _promisifyOrderProps(orders) {
-	return orders.map(
-		({
-			id,
-			status,
-			shippingRate,
-			shippingCarrier,
-			trackingNumber,
-			created_at,
-			products,
-			total}) => Promise.props({
-				id,
-				status,
-				shippingRate,
-				shippingCarrier,
-				trackingNumber,
-				created_at,
-				products,
-				total
-			}))
+  return orders.map(
+    ({
+      id,
+      status,
+      shippingRate,
+      shippingCarrier,
+      trackingNumber,
+      created_at,
+      products,
+      total,
+    }) =>
+      Promise.props({
+        id,
+        status,
+        shippingRate,
+        shippingCarrier,
+        trackingNumber,
+        created_at,
+        products,
+        total,
+      })
+  )
 }

--- a/server/orders.test.js
+++ b/server/orders.test.js
@@ -1,5 +1,5 @@
 const request = require('supertest-as-promised')
-const {expect} = require('chai')
+const { expect } = require('chai')
 const db = require('../db')
 const User = require('../db/models/user')
 const Order = require('../db/models/order')
@@ -9,187 +9,169 @@ const bobTheAdmin = {
   name: 'bobTheAdmin',
   username: 'bob@admins.org',
   password: '12345',
-  isAdmin: true
+  isAdmin: true,
 }
 
 const dallas = {
   name: 'Dallas Malice',
   username: 'dallas@secrets.org',
   password: '12345',
-  isAdmin: false
+  isAdmin: false,
 }
 
 describe('/api/orders/', () => {
-
   describe('GET / (as Non-Admin)', () => {
     const agent = request.agent(app)
-    let user, product, associatedOrder, unassociatedOrder;
+    let user, product, associatedOrder, unassociatedOrder
     before('Create non-admin user and login', () =>
       db.didSync
         .then(() =>
-          User.create(
-            {
-              name: dallas.name,
-              email: dallas.username,
-              password: dallas.password
-            })
+          User.create({
+            name: dallas.name,
+            email: dallas.username,
+            password: dallas.password,
+          })
         )
         .then(_user => {
-          user = _user;
-          return agent
-            .post('/api/auth/local/login')
-            .send(dallas)
+          user = _user
+          return agent.post('/api/auth/local/login').send(dallas)
         })
         .then(res => user.createOrder())
-        .then(_associatedOrder => associatedOrder = _associatedOrder)
+        .then(_associatedOrder => (associatedOrder = _associatedOrder))
         .then(_order => Order.create())
-        .then(_unassociatedOrder => unassociatedOrder = _unassociatedOrder)
+        .then(_unassociatedOrder => (unassociatedOrder = _unassociatedOrder))
     )
 
-    it('returns only the logged-in user orders', () => agent
-      .get('/api/orders/')
-      .expect(200)
-      .then(res => {
-        console.log("RES BODY: ", res.body);
-        expect(res.body).to.have.lengthOf(1);
-        expect(res.body[0].id).to.equal(associatedOrder.id);
-      })
-    )
+    it('returns only the logged-in user orders', () =>
+      agent
+        .get('/api/orders/')
+        .expect(200)
+        .then(res => {
+          console.log('RES BODY: ', res.body)
+          expect(res.body).to.have.lengthOf(1)
+          expect(res.body[0].id).to.equal(associatedOrder.id)
+        }))
     after('logoff and destroy non-admin user', () => {
-      associatedOrder.destroy();
-      unassociatedOrder.destroy();
-      user.destroy();
-      agent.post('/logout');
+      associatedOrder.destroy()
+      unassociatedOrder.destroy()
+      user.destroy()
+      agent.post('/logout')
     })
   })
 
   describe('GET / (as Admin)', () => {
-    let user, order;
+    let user, order
     const agent = request.agent(app)
     before('Create Admin user and Login', () =>
       db.didSync
         .then(() =>
-          User.create(
-            {
-              name: bobTheAdmin.name,
-              email: bobTheAdmin.username,
-              password: bobTheAdmin.password,
-              isAdmin: bobTheAdmin.isAdmin
-            })
+          User.create({
+            name: bobTheAdmin.name,
+            email: bobTheAdmin.username,
+            password: bobTheAdmin.password,
+            isAdmin: bobTheAdmin.isAdmin,
+          })
         )
         .then(_user => {
-          user = _user;
-          return agent
-            .post('/api/auth/local/login')
-            .send(bobTheAdmin)
+          user = _user
+          return agent.post('/api/auth/local/login').send(bobTheAdmin)
         })
         .then(res => Order.create())
-        .then(_order => order = _order)
+        .then(_order => (order = _order))
     )
-    it('returns other user\'s orders if admin', () => agent
-      .get('/api/orders/')
-      .expect(200)
-      .then(res => {
-        expect(res.body[0].id).to.equal(order.id)
-      })
-    )
+    it("returns other user's orders if admin", () =>
+      agent
+        .get('/api/orders/')
+        .expect(200)
+        .then(res => {
+          expect(res.body[0].id).to.equal(order.id)
+        }))
     after('logoff and destroy non-admin user', () => {
-      user.destroy();
-      agent.post('/logout');
+      user.destroy()
+      agent.post('/logout')
     })
   })
 
-
-  xdescribe('POST / (as Guest)', () => {
-
-  })
+  xdescribe('POST / (as Guest)', () => {})
   describe('POST / (as Non-Admin)', () => {
     const agent = request.agent(app)
-    let user, id;
+    let user, id
     before('Create Non-Admin user and Login', () =>
       db.didSync
         .then(() =>
-          User.create(
-            {
-              name: dallas.name,
-              email: dallas.username,
-              password: dallas.password
-            })
+          User.create({
+            name: dallas.name,
+            email: dallas.username,
+            password: dallas.password,
+          })
         )
         .then(_user => {
-          user = _user;
-          return agent
-            .post('/api/auth/local/login')
-            .send(dallas)
+          user = _user
+          return agent.post('/api/auth/local/login').send(dallas)
         })
     )
-    it('adds an order associated with the current logged in user', () => agent
-      .post('/api/orders/')
-      .send({
-        "status": "cancelled",
-        "shippingRate": 9.99,
-        "shippingCarrier": 'UPS',
-        "trackingNumber": null,
-        "orderLineItems": {
-          "1": { "quantity": 10 }
-        }
-      })
-      .expect(200)
-      .then(res => {
-        console.log("==================RES: ", res.body);
-        id = res.body.id;
-        expect(res.body.shippingCarrier).to.equal('UPS');
-        expect(res.body).to.have.property('id');
-        expect(res.body.user_id).to.equal(user.id);
-      })
-    )
+    it('adds an order associated with the current logged in user', () =>
+      agent
+        .post('/api/orders/')
+        .send({
+          status: 'cancelled',
+          shippingRate: 9.99,
+          shippingCarrier: 'UPS',
+          trackingNumber: null,
+          orderLineItems: {
+            1: { quantity: 10 },
+          },
+        })
+        .expect(200)
+        .then(res => {
+          console.log('==================RES: ', res.body)
+          id = res.body.id
+          expect(res.body.shippingCarrier).to.equal('UPS')
+          expect(res.body).to.have.property('id')
+          expect(res.body.user_id).to.equal(user.id)
+        }))
     after('logoff, destroy posts, and destroy non-admin user', () => {
-      agent.post('/logout');
-      user.destroy();
+      agent.post('/logout')
+      user.destroy()
       if (id) {
-        Order.findById(id)
-          .then(order => order.destroy());
+        Order.findById(id).then(order => order.destroy())
       }
     })
   })
   describe('POST / (as Admin)', () => {
     const agent = request.agent(app)
-    let user, id;
+    let user, id
     before('Create Admin user and Login', () =>
       db.didSync
         .then(() =>
-          User.create(
-            {
-              name: bobTheAdmin.name,
-              email: bobTheAdmin.username,
-              password: bobTheAdmin.password,
-              isAdmin: bobTheAdmin.isAdmin
-            })
+          User.create({
+            name: bobTheAdmin.name,
+            email: bobTheAdmin.username,
+            password: bobTheAdmin.password,
+            isAdmin: bobTheAdmin.isAdmin,
+          })
         )
         .then(_user => {
-          user = _user;
-          return agent
-            .post('/api/auth/local/login')
-            .send(bobTheAdmin)
+          user = _user
+          return agent.post('/api/auth/local/login').send(bobTheAdmin)
         })
     )
-    it('adds an order unassociated with a particular user', () => agent
-      .post('/api/orders/')
-      .send({ "shippingCarrier": "USPS" })
-      .expect(200)
-      .then(res => {
-        id = res.body.id;
-        expect(res.body.shippingCarrier).to.equal('USPS');
-        expect(res.body).to.have.property('id');
-        expect(res.body).to.have.property('user_id');
-        expect(res.body.user_id).to.be.null;
-      })
-    )
+    it('adds an order unassociated with a particular user', () =>
+      agent
+        .post('/api/orders/')
+        .send({ shippingCarrier: 'USPS' })
+        .expect(200)
+        .then(res => {
+          id = res.body.id
+          expect(res.body.shippingCarrier).to.equal('USPS')
+          expect(res.body).to.have.property('id')
+          expect(res.body).to.have.property('user_id')
+          expect(res.body.user_id).to.be.null
+        }))
     after('logoff, destroy posts, and destroy admin user', () => {
-      agent.post('/logout');
-      user.destroy();
-      Order.findById(id)
-        .then(order => order.destroy());
+      agent.post('/logout')
+      user.destroy()
+      Order.findById(id).then(order => order.destroy())
     })
   })
 })

--- a/server/products.js
+++ b/server/products.js
@@ -3,7 +3,8 @@
 const db = require('../db')
 const Product = require('../db/models/product')
 
-module.exports = require('express').Router()
+module.exports = require('express')
+  .Router()
 
   // Action: List all the cookies
   // Roles: Guest, User, Admin
@@ -11,32 +12,34 @@ module.exports = require('express').Router()
     Product.findAll()
       .then(products => {
         if (products.length > 0) {
-          res.json(products);
+          res.json(products)
         } else {
-          res.sendStatus(404);
+          res.sendStatus(404)
         }
       })
-      .catch(next))
+      .catch(next)
+  )
 
   // Action: Create a new type of cookie
   // Roles: Admin
   .post('/', (req, res, next) =>
     Product.create(req.body)
       .then(product => res.json(product))
-      .catch(next))
+      .catch(next)
+  )
 
   // Use Param to DRY subsequent routes
   .param('id', function (req, res, next) {
     Product.findById(req.params.id)
       .then(product => {
         if (product) {
-          req.product = product;
-          next();
+          req.product = product
+          next()
         } else {
-          res.sendStatus(404);
+          res.sendStatus(404)
         }
       })
-      .catch(next);
+      .catch(next)
   })
 
   // Action: List a single type of cookie by cookie id
@@ -48,7 +51,8 @@ module.exports = require('express').Router()
   // Action: Modify a cookie by id
   // Roles: Admin
   .put('/:id', (req, res, next) => {
-    req.product.update(req.body)
+    req.product
+      .update(req.body)
       .then(order => res.status(200).json(order))
       .catch(next)
   })
@@ -56,7 +60,8 @@ module.exports = require('express').Router()
   // Action: Delete a cookie by id. Oh NOOO!!!
   // Roles: Admin
   .delete('/:id', (req, res, next) => {
-    req.product.destroy()
+    req.product
+      .destroy()
       .then(() => res.sendStatus(200))
       .catch(next)
   })

--- a/server/products.test.js
+++ b/server/products.test.js
@@ -1,19 +1,15 @@
 const request = require('supertest-as-promised')
-const {expect} = require('chai')
+const { expect } = require('chai')
 const db = require('../db')
 const Product = require('../db/models/product')
 const app = require('./start')
-
 
 describe('/api/products', () => {
   describe('GET /', () => {
     // We should insert two products using Sequelize, call the route, and check that
     // the output returned 200 and contained the products we inserted.
     xit('returns all types of cookies', () =>
-      request(app)
-        .get(`/api/products`)
-        .expect(200)
-    )
+      request(app).get(`/api/products`).expect(200))
   })
 
   describe('GET /:id', () => {
@@ -21,10 +17,7 @@ describe('/api/products', () => {
     // then inoke the get /:id route with the product ID we retrieved to check
     // that we got the new product
     xit('returns (1) type of cookie by id', () =>
-      request(app)
-        .get('/api/reviews/1')
-        .expect(200)
-    )
+      request(app).get('/api/reviews/1').expect(200))
   })
 
   describe('POST / (????)', () => {
@@ -36,10 +29,9 @@ describe('/api/products', () => {
         .send({
           title: 'Your products are terrible!',
           email: 'angrycustomer@altivista.net',
-          rating: 1
+          rating: 1,
         })
-        .expect(201)
-    )
+        .expect(201))
   })
 
   describe('PUT / (????)', () => {
@@ -50,10 +42,9 @@ describe('/api/products', () => {
         .send({
           title: 'Your products are terrible!',
           email: 'angrycustomer@altivista.net',
-          rating: 1
+          rating: 1,
         })
-        .expect(201)
-    )
+        .expect(201))
   })
 
   describe('DELETE /:id', () => {
@@ -64,10 +55,8 @@ describe('/api/products', () => {
         .send({
           title: 'Your products are terrible!',
           email: 'angrycustomer@altivista.net',
-          rating: 1
+          rating: 1,
         })
-        .expect(201)
-    )
+        .expect(201))
   })
-
 })

--- a/server/reviews.js
+++ b/server/reviews.js
@@ -1,14 +1,16 @@
-const db = require('../db');
-const Review = require('../db/models/review');
+const db = require('../db')
+const Review = require('../db/models/review')
 
-module.exports = require('express').Router()
+module.exports = require('express')
+  .Router()
 
   // Action: View all reviews
   // Roles: Guest, User, Admin
   .get('/', (req, res, next) =>
     Review.findAll()
       .then(reviews => res.json(reviews))
-      .catch(next))
+      .catch(next)
+  )
 
   // Action: Create a new review
   // Roles: User, Admin
@@ -17,8 +19,8 @@ module.exports = require('express').Router()
   .post('/', (req, res, next) =>
     Review.create(req.body)
       .then(review => res.status(201).json(review))
-      .catch(next))
-
+      .catch(next)
+  )
 
   // TODO: Implement router param for review ID
 
@@ -27,16 +29,17 @@ module.exports = require('express').Router()
   .get('/:id', (req, res, next) =>
     Review.findById(req.params.id)
       .then(review => res.json(review))
-      .catch(next))
+      .catch(next)
+  )
 
-  // Action: Modify a single existing review by ID
-  // Roles: User, Admin
-  // Notes: Users can only modify reviews that they wrote
-  // TODO: Implement put route for modifying a single review
-  // .put('/:id', (req, res, next)
+// Action: Modify a single existing review by ID
+// Roles: User, Admin
+// Notes: Users can only modify reviews that they wrote
+// TODO: Implement put route for modifying a single review
+// .put('/:id', (req, res, next)
 
-  // Action: Delete a single existing review by ID
-  // Roles: User, Admin
-  // Notes: Users can only modify delete that they wrote
-  // TODO: Implement delete route for deleting a single review
-  // .put('/:id', (req, res, next)
+// Action: Delete a single existing review by ID
+// Roles: User, Admin
+// Notes: Users can only modify delete that they wrote
+// TODO: Implement delete route for deleting a single review
+// .put('/:id', (req, res, next)

--- a/server/reviews.test.js
+++ b/server/reviews.test.js
@@ -1,5 +1,5 @@
 const request = require('supertest-as-promised')
-const {expect} = require('chai')
+const { expect } = require('chai')
 const db = require('../db')
 const Review = require('../db/models/review')
 const app = require('./start')
@@ -7,10 +7,7 @@ const app = require('./start')
 describe('/api/reviews', () => {
   describe('Basic functionality', () => {
     it('GET / returns all reviews', () =>
-      request(app)
-        .get(`/api/reviews`)
-        .expect(200)
-    )
+      request(app).get(`/api/reviews`).expect(200))
 
     it('POST creates a review', () =>
       request(app)
@@ -18,15 +15,11 @@ describe('/api/reviews', () => {
         .send({
           title: 'Your products are terrible!',
           email: 'angrycustomer@altivista.net',
-          rating: 1
+          rating: 1,
         })
-        .expect(201)
-    )
+        .expect(201))
 
     it('GET /:id returns (1) review by id', () =>
-      request(app)
-        .get('/api/reviews/1')
-        .expect(200)
-    )
+      request(app).get('/api/reviews/1').expect(200))
   })
 })

--- a/server/start.js
+++ b/server/start.js
@@ -2,7 +2,7 @@
 
 const express = require('express')
 const bodyParser = require('body-parser')
-const {resolve} = require('path')
+const { resolve } = require('path')
 const passport = require('passport')
 
 const pkg = require('../index.js')
@@ -16,10 +16,12 @@ if (!pkg.isProduction && !pkg.isTesting) {
 
 module.exports = app
   // We'll store the whole session in a cookie
-  .use(require('cookie-session') ({
-    name: 'session',
-    keys: [process.env.SESSION_SECRET || 'an insecure secret key'],
-  }))
+  .use(
+    require('cookie-session')({
+      name: 'session',
+      keys: [process.env.SESSION_SECRET || 'an insecure secret key'],
+    })
+  )
 
   // Body parsing middleware
   .use(bodyParser.urlencoded({ extended: true }))
@@ -36,17 +38,16 @@ module.exports = app
   .use('/api', require('./api'))
 
   // Send index.html for anything else.
-  .get('/*', (_, res) => res.sendFile(resolve(__dirname, '..', 'public', 'index.html')))
+  .get('/*', (_, res) =>
+    res.sendFile(resolve(__dirname, '..', 'public', 'index.html'))
+  )
 
 if (module === require.main) {
   // Start listening only if we're the main module.
   //
   // https://nodejs.org/api/modules.html#modules_accessing_the_main_module
-  const server = app.listen(
-    process.env.PORT || 1337,
-    () => {
-      console.log(`--- Started HTTP Server for ${pkg.name} ---`)
-      console.log(`Listening on ${JSON.stringify(server.address())}`)
-    }
-  )
+  const server = app.listen(process.env.PORT || 1337, () => {
+    console.log(`--- Started HTTP Server for ${pkg.name} ---`)
+    console.log(`Listening on ${JSON.stringify(server.address())}`)
+  })
 }

--- a/server/users.js
+++ b/server/users.js
@@ -1,69 +1,70 @@
-'use strict';
+'use strict'
 
-const db = require('../db');
-const User = db.model('users');
+const db = require('../db')
+const User = db.model('users')
 
-const {mustBeLoggedIn, selfOnlyOrAdmin, forbidden} = require('./auth.filters');
+const { mustBeLoggedIn, selfOnlyOrAdmin, forbidden } = require('./auth.filters')
 // const selfOrAdmin = selfOnlyOrAdmin("select");
 // console.log(selfOnlyOrAdmin("select"));
-module.exports = require('express').Router()
+module.exports = require('express')
+  .Router()
 
-	// Action: View All users
-	// Roles: Admin
-	// Notes:
-	.get('/', mustBeLoggedIn, (req, res, next) => {
-		if (req.user.isAdmin) {
-			User.findAll()
-				.then(users => res.json(users))
-				.catch(next)
-		} else {
-			forbidden('only admins can list all users')
-		}
-	})
+  // Action: View All users
+  // Roles: Admin
+  // Notes:
+  .get('/', mustBeLoggedIn, (req, res, next) => {
+    if (req.user.isAdmin) {
+      User.findAll()
+        .then(users => res.json(users))
+        .catch(next)
+    } else {
+      forbidden('only admins can list all users')
+    }
+  })
 
-	// Action: Create a new user
-	// Roles: Guest, Admin
-	// Notes: A signed in user should not be able to create a new user
-	// TODO: Harden this route.
-	.post('/', (req, res, next) => { //selfOnlyOrAdmin,
-		return User.create(req.body)
-			.then(user => res.status(201).json(user))
-			.catch(next)
-	})
+  // Action: Create a new user
+  // Roles: Guest, Admin
+  // Notes: A signed in user should not be able to create a new user
+  // TODO: Harden this route.
+  .post('/', (req, res, next) => {
+    //selfOnlyOrAdmin,
+    return User.create(req.body)
+      .then(user => res.status(201).json(user))
+      .catch(next)
+  })
 
-	// Action: Param for User ID
-	// Roles: User, Admin
-	// Notes: A User should only be able to see their own stuff
-	.param('id', mustBeLoggedIn, function (req, res, next) { //selfOnlyOrAdmin,
-		User.findById(req.params.id)
-			.then(user => {
-				if (user) {
-					req.foundUser = user; //DO NOT KLOBBER PASSPORT BY USING REQ.USER!!!!
-					next();
-				} else {
-					res.sendStatus(404);
-				}
-			})
-			.catch(next);
-	})
+  // Action: Param for User ID
+  // Roles: User, Admin
+  // Notes: A User should only be able to see their own stuff
+  .param('id', mustBeLoggedIn, function (req, res, next) {
+    //selfOnlyOrAdmin,
+    User.findById(req.params.id)
+      .then(user => {
+        if (user) {
+          req.foundUser = user //DO NOT KLOBBER PASSPORT BY USING REQ.USER!!!!
+          next()
+        } else {
+          res.sendStatus(404)
+        }
+      })
+      .catch(next)
+  })
 
-	// Action: Get user by ID
-	// Roles: User, Admin
-	// Notes:
-	.get('/:id', (req, res, next) =>
-		res.status(200).json(req.foundUser))
+  // Action: Get user by ID
+  // Roles: User, Admin
+  // Notes:
+  .get('/:id', (req, res, next) => res.status(200).json(req.foundUser))
 
-	// Action: Modify user by ID
-	// Roles: User, Admin
-	// Notes:
-	// TODO: Implement
-	// .put('/:id', (req, res, next) =>
-	// 	res.status(200).json(req.foundUser))
+// Action: Modify user by ID
+// Roles: User, Admin
+// Notes:
+// TODO: Implement
+// .put('/:id', (req, res, next) =>
+// 	res.status(200).json(req.foundUser))
 
-	// Action: Delete user by ID
-	// Roles: User, Admin
-	// Notes:
-	// TODO: Implement delete
-	// .delete('/:id', (req, res, next) =>
-	// 	res.status(200).json(req.foundUser))
-
+// Action: Delete user by ID
+// Roles: User, Admin
+// Notes:
+// TODO: Implement delete
+// .delete('/:id', (req, res, next) =>
+// 	res.status(200).json(req.foundUser))

--- a/server/users.test.js
+++ b/server/users.test.js
@@ -1,5 +1,5 @@
 const request = require('supertest-as-promised')
-const {expect} = require('chai')
+const { expect } = require('chai')
 const db = require('../db')
 const User = require('../db/models/user')
 const app = require('./start')
@@ -7,10 +7,7 @@ const app = require('./start')
 describe('/api/users', () => {
   describe('when not logged in', () => {
     it('GET /:id fails 401 (Unauthorized)', () =>
-      request(app)
-        .get(`/api/users/1`)
-        .expect(401)
-    )
+      request(app).get(`/api/users/1`).expect(401))
 
     it('POST creates a user', () =>
       request(app)
@@ -18,10 +15,9 @@ describe('/api/users', () => {
         .send({
           name: 'Beth the Spy',
           email: 'beth@secrets.org',
-          password: '12345'
+          password: '12345',
         })
-        .expect(201)
-    )
+        .expect(201))
 
     xit('POST redirects to the user it just made', () =>
       request(app)
@@ -31,9 +27,10 @@ describe('/api/users', () => {
           password: '23456',
         })
         .redirects(1)
-        .then(res => expect(res.body).to.contain({
-          email: 'eve@interloper.com'
-        }))
-    )
+        .then(res =>
+          expect(res.body).to.contain({
+            email: 'eve@interloper.com',
+          })
+        ))
   })
 })


### PR DESCRIPTION
## Summary

- Adds **ESLint 8** + **Prettier 2** (Node 12-compatible versions)
- Runs Prettier across all 60 source files to establish a consistent formatting baseline — no logic changes, whitespace/quote normalization only
- Adds **`.gitattributes`** to normalize line endings to LF

## Config choices

**ESLint (`.eslintrc.json`)**
- Parser: ESLint's built-in espree with `ecmaFeatures.jsx: true` — `babel-eslint@10` was dropped because it's incompatible with ESLint 8's ESM internals
- Extends: `eslint:recommended` → `plugin:react/recommended` → `prettier` (prettier last to override any conflicting style rules)
- `no-console: warn`, `no-unused-vars: warn` — warnings rather than errors since existing code is noisy; can be tightened in follow-up PRs
- `react/prop-types: off` — not enforced in this codebase
- `overrides` adds `env.mocha: true` for `*.test.{js,jsx}` so `describe`/`it`/`before` are recognized globals

**Prettier (`.prettierrc`)**
- Matches existing code style: single quotes, no semicolons, `trailingComma: es5`, `printWidth: 80`

## ESLint baseline

`npm run lint` currently reports **64 warnings + 5 errors**. The errors are pre-existing bugs surfaced by the linter — not introduced by this PR:

| File | Issue |
|---|---|
| `db/models/oauth.js` | `token` and `User` undefined in the V2 Passport handler — broken OAuth feature |
| `index.js:34` | `baseUrl` getter uses `${PORT}` (undefined) instead of `${env.PORT \|\| 1337}` |

These will be fixed in follow-up PRs. Keeping this PR scoped to tooling only.

## New scripts

```
npm run lint          # eslint app/ server/ db/ index.js
npm run lint:fix      # eslint --fix ...
npm run format        # prettier --write ...
npm run format:check  # prettier --check ...
```

## Reviewer notes

The large diff is entirely Prettier reformatting (quote style, trailing commas, indentation consistency). No application behaviour changed. The easiest way to review is to hide whitespace changes.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)