### PR TITLE
chore: remove jQuery dependency

### DIFF
--- a/app/components/Nav.jsx
+++ b/app/components/Nav.jsx
@@ -1,19 +1,20 @@
 'use strict'
 
-import React, { Component } from 'react'
+import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
 
-export default props => (
+export default props => {
+  const [navOpen, setNavOpen] = useState(false)
+  return (
   <nav className="navbar navbar-default">
     <div className="container-fluid">
       {/* Brand and toggle get grouped for better mobile display */}
       <div className="navbar-header">
         <button
           type="button"
-          className="navbar-toggle collapsed"
-          data-toggle="collapse"
-          data-target="#bs-example-navbar-collapse-1"
-          aria-expanded="false"
+          className={`navbar-toggle${navOpen ? '' : ' collapsed'}`}
+          onClick={() => setNavOpen(open => !open)}
+          aria-expanded={navOpen}
         >
           <span className="sr-only">Toggle navigation</span>
           <span className="icon-bar" />
@@ -27,7 +28,7 @@ export default props => (
       </div>
       {/* Collect the nav links, forms, and other content for toggling */}
       <div
-        className="collapse navbar-collapse"
+        className={`collapse navbar-collapse${navOpen ? ' in' : ''}`}
         id="bs-example-navbar-collapse-1"
       >
         {/* handles if user is logged in or not */}
@@ -87,4 +88,5 @@ export default props => (
     </div>
     {/* /.container-fluid */}
   </nav>
-)
+  )
+}

--- a/app/components/Product.jsx
+++ b/app/components/Product.jsx
@@ -1,54 +1,57 @@
 'use strict'
 
-import React, { Component } from 'react'
+import React, { useRef } from 'react'
 import { Link } from 'react-router-dom'
 
-export default ({ cookie, plusItemzToCart }) => (
-  <div className="col-xs-18 col-sm-6 col-md-3">
-    <div className="thumbnail">
-      <div className="cookieContainer">
-        <img className="cookieImage" src={cookie.photo} />
-      </div>
-      <div className="caption">
-        {/* Handles case of Seinfeld's race relations cookie discussion */}
-        <h4>
-          {cookie.name === 'Black & White Cookie' ? (
-            <a href="https://www.youtube.com/watch?v=IlLPAIrmqvE">
-              {cookie.name}
+export default ({ cookie, plusItemzToCart }) => {
+  const quantityRef = useRef(null)
+  return (
+    <div className="col-xs-18 col-sm-6 col-md-3">
+      <div className="thumbnail">
+        <div className="cookieContainer">
+          <img className="cookieImage" src={cookie.photo} />
+        </div>
+        <div className="caption">
+          {/* Handles case of Seinfeld's race relations cookie discussion */}
+          <h4>
+            {cookie.name === 'Black & White Cookie' ? (
+              <a href="https://www.youtube.com/watch?v=IlLPAIrmqvE">
+                {cookie.name}
+              </a>
+            ) : (
+              cookie.name
+            )}
+          </h4>
+          <p>{cookie.description}</p>
+          <p className="cookieCategory">
+            {cookie.categories.map(category => category).join(', ')}
+          </p>
+          <p>
+            <Link to="/reviews">Reviews</Link>
+          </p>
+          <p>
+            <span id="quantityText">Quantity: </span>
+            <input
+              ref={quantityRef}
+              className="form-control quantity"
+              name="quantity"
+              defaultValue="1"
+            />
+            <a
+              className="btn btn-info btn-sm"
+              role="button"
+              onClick={evt => {
+                evt.preventDefault()
+                const quantity = parseInt(quantityRef.current.value)
+                plusItemzToCart(cookie, quantity)
+                alert(`Added ${quantity} ${cookie.name} to cart`)
+              }}
+            >
+              Add to cart
             </a>
-          ) : (
-            cookie.name
-          )}
-        </h4>
-        <p>{cookie.description}</p>
-        <p className="cookieCategory">
-          {cookie.categories.map(category => category).join(', ')}
-        </p>
-        <p>
-          <Link to="/reviews">Reviews</Link>
-        </p>
-        <p>
-          <span id="quantityText">Quantity: </span>
-          <input
-            id={`number_of_cookie_${cookie.id}`}
-            className="form-control quantity"
-            name="quantity"
-            defaultValue="1"
-          />
-          <a
-            className="btn btn-info btn-sm"
-            role="button"
-            onClick={evt => {
-              evt.preventDefault()
-              let quantity = parseInt($(`#number_of_cookie_${cookie.id}`).val())
-              plusItemzToCart(cookie, quantity)
-              alert(`Added ${quantity} ${cookie.name} to cart`)
-            }}
-          >
-            Add to cart
-          </a>
-        </p>
+          </p>
+        </div>
       </div>
     </div>
-  </div>
-)
+  )
+}

--- a/public/index.html
+++ b/public/index.html
@@ -6,8 +6,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
     <link href="/style.css" rel="stylesheet" />
-    <script src="https://code.jquery.com/jquery-3.1.1.min.js" integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8=" crossorigin="anonymous"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+
   </head>
   <body>
     <div id=main></div>


### PR DESCRIPTION
## Summary

- **Product.jsx**: replace `$(\`#number_of_cookie_${id}\`).val()` with a React `useRef` attached to the quantity input — no more global `$` needed
- **Nav.jsx**: replace `data-toggle="collapse"` + Bootstrap 3 JS with React `useState`; toggle button adds/removes `collapsed` class and collapse div adds/removes Bootstrap 3's `in` class
- **public/index.html**: remove jQuery 3.1.1 CDN script and Bootstrap 3.3.7 JS CDN script

## Test plan

- [x] `npm run build` — 0 errors
- [x] `npm test` — 20 passing, 0 failing
- [x] Login and add-to-cart work (useRef reads quantity correctly)
- [x] Navbar toggle opens and closes the mobile menu (useState toggles `in`/`collapsed` classes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)