### PR TITLE
chore: upgrade Bootstrap 3 → 5

### DIFF
--- a/app/components/Cart.jsx
+++ b/app/components/Cart.jsx
@@ -12,7 +12,7 @@ export default props => {
     total += cartLineItem.product.price * cartLineItem.quantity
   })
   return (
-    <div className="pull-right">
+    <div className="float-end">
       <p id="cartPreviewText">
         <i id="cartPreviewIcon" className="fa fa-shopping-cart"></i>
         <span> {numOfItems}</span> items totaling{' '}

--- a/app/components/CartEmpty.jsx
+++ b/app/components/CartEmpty.jsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react'
 export default props => {
   return (
     <div id="cart-empty-container" className="container">
-      <div className="jumbotron center">
+      <div className="p-5 mb-4 bg-light rounded-3 text-center">
         <h1>Uh oh!...</h1>
         <br />
         <p>You have no cookies in your cart. Add some cookies, ya idiot!</p>

--- a/app/components/CartLineItem.jsx
+++ b/app/components/CartLineItem.jsx
@@ -6,34 +6,32 @@ import { Link } from 'react-router-dom'
 export default props => {
   return (
     <div id="cart-line-item" className="container">
-      <div className="panel panel-success">
-        <div className="panel-heading">
+      <div className="card border-success">
+        <div className="card-header">
           <div className="row">
-            <div className="col-sm-10 col-xs-9">
-              <h3 className="panel-title text-left">{props.name}</h3>
+            <div className="col-sm-10 col-9">
+              <h3 className="card-title text-start">{props.name}</h3>
             </div>
-            <div className="col-sm-2 col-xs-3 text-right">
+            <div className="col-sm-2 col-3 text-end">
               <button id="remove-from-cart" className="btn btn-sm btn-danger">
                 Remove
               </button>
             </div>
           </div>
         </div>
-        <div className="panel-body">
-          <div className="media">
-            <div className="media-left">
-              <div className="thumbContainer">
-                <Link to="/reviews">
-                  {' '}
-                  <img
-                    className="thumbImg"
-                    src={props.photo}
-                    alt={props.name}
-                  />
-                </Link>
-              </div>
+        <div className="card-body">
+          <div className="d-flex gap-3">
+            <div className="thumbContainer">
+              <Link to="/reviews">
+                {' '}
+                <img
+                  className="thumbImg"
+                  src={props.photo}
+                  alt={props.name}
+                />
+              </Link>
             </div>
-            <div className="media-body">
+            <div>
               <p>{props.description}</p>
               <p>Qty: {props.quantity}</p>
               <p>Price: ${(props.price * props.quantity).toFixed(2)}</p>

--- a/app/components/Hero.jsx
+++ b/app/components/Hero.jsx
@@ -4,12 +4,12 @@ import Cart from '../containers/CartContainer'
 export default function (props) {
   return (
     <div id="headerRow" className="row">
-      <div className="col-sm-6 col-xs-12">
+      <div className="col-sm-6 col-12">
         <img className="cookieMonsterImg" src="/images/cookie-monster.jpg" />
         <h1>Cookie Monsters</h1>
         <h3 className="subtitle">Home of the world's greatest cookies</h3>
       </div>
-      <div id="cartRow" className="col-sm-6 col-xs-12">
+      <div id="cartRow" className="col-sm-6 col-12">
         <Cart />
       </div>
       <br />

--- a/app/components/MyOrders.jsx
+++ b/app/components/MyOrders.jsx
@@ -9,7 +9,7 @@ export default props => {
       {/* Handle if no orders */}
       {props.orders.length === 0 ? (
         <div className="container">
-          <div id="no-orders" className="jumbotron center">
+          <div id="no-orders" className="p-5 mb-4 bg-light rounded-3 text-center">
             <div>
               <p>
                 You haven't placed any orders yet. <br />

--- a/app/components/MyOrdersItem.jsx
+++ b/app/components/MyOrdersItem.jsx
@@ -5,27 +5,20 @@ import { Link } from 'react-router-dom'
 
 export default props => {
   return (
-    <div className="panel panel-success">
-      <div className="panel-heading">
-        {/* Link to order detail */}
+    <div className="card border-success mb-3">
+      <div className="card-header">
         <Link onClick={evt => props.selectOrder(props.order)} to="/order">
-          <h3 className="panel-title">Order ID: {props.order.id}</h3>
+          <h3 className="card-title">Order ID: {props.order.id}</h3>
         </Link>
       </div>
-      <div className="panel-body">
-        <div className="media">
-          <div className="media-body">
-            {/* Shipping information */}
-            <p>Order created {props.order.created_at}</p>
-            <p>
-              Shipped by{' '}
-              {props.order.shippingCarrier || 'Omri in a beige Dodge Van'} on
-              January 15, 2017
-            </p>
-            {/* Order total */}
-            <p>Total: ${props.order.total}</p>
-          </div>
-        </div>
+      <div className="card-body">
+        <p>Order created {props.order.created_at}</p>
+        <p>
+          Shipped by{' '}
+          {props.order.shippingCarrier || 'Omri in a beige Dodge Van'} on
+          January 15, 2017
+        </p>
+        <p>Total: ${props.order.total}</p>
       </div>
     </div>
   )

--- a/app/components/Nav.jsx
+++ b/app/components/Nav.jsx
@@ -6,87 +6,75 @@ import { Link } from 'react-router-dom'
 export default props => {
   const [navOpen, setNavOpen] = useState(false)
   return (
-  <nav className="navbar navbar-default">
-    <div className="container-fluid">
-      {/* Brand and toggle get grouped for better mobile display */}
-      <div className="navbar-header">
-        <button
-          type="button"
-          className={`navbar-toggle${navOpen ? '' : ' collapsed'}`}
-          onClick={() => setNavOpen(open => !open)}
-          aria-expanded={navOpen}
-        >
-          <span className="sr-only">Toggle navigation</span>
-          <span className="icon-bar" />
-          <span className="icon-bar" />
-          <span className="icon-bar" />
-        </button>
+    <nav className="navbar navbar-expand-lg navbar-light bg-light">
+      <div className="container-fluid">
         <a className="navbar-brand" href="/products">
           <img id="brand" alt="Brand" src="/images/brand.png" />
           <span id="brand-title">Cookie Monsters</span>
         </a>
-      </div>
-      {/* Collect the nav links, forms, and other content for toggling */}
-      <div
-        className={`collapse navbar-collapse${navOpen ? ' in' : ''}`}
-        id="bs-example-navbar-collapse-1"
-      >
-        {/* handles if user is logged in or not */}
-        {/* have to put ul's inside ternary for styling purposes */}
-        {props.auth ? (
-          <ul className="nav navbar-nav navbar-right">
-            <li>
-              {/* TODO: this link doesn't work correctly yet */}
-              <p className="navbar-text">
-                Hello,{' '}
+        <button
+          type="button"
+          className={`navbar-toggler${navOpen ? '' : ' collapsed'}`}
+          onClick={() => setNavOpen(open => !open)}
+          aria-expanded={navOpen}
+        >
+          <span className="visually-hidden">Toggle navigation</span>
+          <span className="navbar-toggler-icon" />
+        </button>
+        <div
+          className={`collapse navbar-collapse${navOpen ? ' show' : ''}`}
+          id="bs-example-navbar-collapse-1"
+        >
+          {props.auth ? (
+            <ul className="navbar-nav ms-auto">
+              <li className="nav-item">
+                <p className="navbar-text">
+                  Hello,{' '}
+                  <a
+                    onClick={evt => {
+                      evt.preventDefault()
+                      props.selectUser(props.auth)
+                    }}
+                  >
+                    {props.auth.name}
+                  </a>
+                  !
+                </p>
+              </li>
+              <li className="nav-item">
+                <Link className="nav-link" to="/myorders">My Orders</Link>
+              </li>
+              {props.auth.isAdmin ? (
+                <li className="nav-item">
+                  <Link className="nav-link" to="/users">Users</Link>
+                </li>
+              ) : (
+                ''
+              )}
+              <li className="nav-item">
                 <a
+                  className="nav-link"
                   onClick={evt => {
                     evt.preventDefault()
-                    props.selectUser(props.auth)
+                    props.logout()
                   }}
                 >
-                  {props.auth.name}
+                  Logout
                 </a>
-                !
-              </p>
-            </li>
-            <li>
-              <Link to="/myorders">My Orders</Link>
-            </li>
-            {props.auth.isAdmin ? (
-              <li>
-                <Link to="/users">Users</Link>
-              </li>
-            ) : (
-              ''
-            )}
-            <li>
-              <a
-                onClick={evt => {
-                  evt.preventDefault()
-                  props.logout()
-                }}
-              >
-                Logout
-              </a>
-            </li>
-          </ul>
-        ) : (
-          <div>
-            <ul className="nav navbar-nav navbar-right">
-              <li>
-                <Link to="/signup">Sign Up</Link>
-              </li>
-              <li>
-                <Link to="/login">Login</Link>
               </li>
             </ul>
-          </div>
-        )}
+          ) : (
+            <ul className="navbar-nav ms-auto">
+              <li className="nav-item">
+                <Link className="nav-link" to="/signup">Sign Up</Link>
+              </li>
+              <li className="nav-item">
+                <Link className="nav-link" to="/login">Login</Link>
+              </li>
+            </ul>
+          )}
+        </div>
       </div>
-      {/* /.navbar-collapse */}
-    </div>
-    {/* /.container-fluid */}
-  </nav>
+    </nav>
   )
 }

--- a/app/components/Order.jsx
+++ b/app/components/Order.jsx
@@ -13,7 +13,7 @@ export default props => {
       </div>
       <div id="orderDetail">
         <p className="lead">Cookie Order {props.order.id}</p>
-        <table className="table table-responsive table-borderless">
+        <div className="table-responsive"><table className="table table-borderless">
           <thead>
             <tr>
               <th>Quantity</th>
@@ -24,14 +24,14 @@ export default props => {
           <tfoot>
             <tr>
               <td></td>
-              <td className="pull-right orderTableFooterTitles">
+              <td className="float-end orderTableFooterTitles">
                 Flat Shipping Rate
               </td>
               <td>${props.order.shippingRate}</td>
             </tr>
             <tr>
               <td></td>
-              <td className="pull-right orderTableFooterTitles">Total</td>
+              <td className="float-end orderTableFooterTitles">Total</td>
               <td>${props.order.total}</td>
             </tr>
             <tr>
@@ -49,7 +49,7 @@ export default props => {
               </tr>
             ))}
           </tbody>
-        </table>
+        </table></div>
         {/* This should appear after order is submitted */}
         <div className="lead">
           Cookies shipped by{' '}

--- a/app/components/Product.jsx
+++ b/app/components/Product.jsx
@@ -6,12 +6,12 @@ import { Link } from 'react-router-dom'
 export default ({ cookie, plusItemzToCart }) => {
   const quantityRef = useRef(null)
   return (
-    <div className="col-xs-18 col-sm-6 col-md-3">
-      <div className="thumbnail">
+    <div className="col-12 col-sm-6 col-md-3">
+      <div className="card">
         <div className="cookieContainer">
           <img className="cookieImage" src={cookie.photo} />
         </div>
-        <div className="caption">
+        <div className="card-body">
           {/* Handles case of Seinfeld's race relations cookie discussion */}
           <h4>
             {cookie.name === 'Black & White Cookie' ? (

--- a/app/components/Reviews.jsx
+++ b/app/components/Reviews.jsx
@@ -14,7 +14,7 @@ export default () => (
     </div>
 
     <div id="reviews" className="row">
-      <div className="col-xs-12 col-sm-6 col-md-4">
+      <div className="col-12 col-sm-6 col-md-4">
         <div className="cookieContainer">
           <img
             className="cookieImage"
@@ -22,7 +22,7 @@ export default () => (
           />
         </div>
       </div>
-      <div className="col-xs-12 col-sm-6 col-md-8">
+      <div className="col-12 col-sm-6 col-md-8">
         {/* REVIEW PRODUCT NAME */}
         <h3 id="reviewTitle">Chocolate Chip Cookie</h3>
         {/* Loop on this for product reviews */}

--- a/app/components/User.jsx
+++ b/app/components/User.jsx
@@ -10,9 +10,9 @@ export default props => {
   }
   return (
     <div className="container">
-      <div className="col-xs-12 col-sm-4">
+      <div className="col-12 col-sm-4">
         <h2>{user.name}</h2>
-        <div className="form-group">
+        <div className="mb-3">
           <label htmlFor="name">Name</label>
           <input
             type="text"
@@ -22,7 +22,7 @@ export default props => {
             value={user.name}
           />
         </div>
-        <div className="form-group">
+        <div className="mb-3">
           <label htmlFor="email">Email address</label>
           <input
             type="email"
@@ -36,7 +36,7 @@ export default props => {
           </small>
         </div>
         <h4>Billing Address</h4>
-        <div className="form-group">
+        <div className="mb-3">
           <label htmlFor="billingAddress">Address</label>
           <input
             type="text"
@@ -46,7 +46,7 @@ export default props => {
             value={user.billingAddress}
           />
         </div>
-        <div className="form-group">
+        <div className="mb-3">
           <label htmlFor="billingCity">City</label>
           <input
             type="text"
@@ -56,7 +56,7 @@ export default props => {
             value={user.billingCity}
           />
         </div>
-        <div className="form-group">
+        <div className="mb-3">
           <label htmlFor="billingState">State</label>
           <input
             type="text"
@@ -66,7 +66,7 @@ export default props => {
             value={user.billingState}
           />
         </div>
-        <div className="form-group">
+        <div className="mb-3">
           <label htmlFor="billingZip">Zip Code</label>
           <input
             type="text"
@@ -77,7 +77,7 @@ export default props => {
           />
         </div>
         <h4>Shipping Address</h4>
-        <div className="form-group">
+        <div className="mb-3">
           <label htmlFor="shippingAddress">Address</label>
           <input
             type="text"
@@ -87,7 +87,7 @@ export default props => {
             value={user.shippingAddress}
           />
         </div>
-        <div className="form-group">
+        <div className="mb-3">
           <label htmlFor="shippingCity">City</label>
           <input
             type="text"
@@ -97,7 +97,7 @@ export default props => {
             value={user.shippingCity}
           />
         </div>
-        <div className="form-group">
+        <div className="mb-3">
           <label htmlFor="shippingState">State</label>
           <input
             type="text"
@@ -107,7 +107,7 @@ export default props => {
             value={user.shippingState}
           />
         </div>
-        <div className="form-group">
+        <div className="mb-3">
           <label htmlFor="shippingZip">Zip Code</label>
           <input
             type="text"
@@ -118,7 +118,7 @@ export default props => {
           />
         </div>
         {props.auth && props.auth.isAdmin ? (
-          <fieldset className="form-group">
+          <fieldset className="mb-3">
             <legend>
               {user.name}{' '}
               {user.isAdmin
@@ -158,7 +158,7 @@ export default props => {
         <button type="submit" className="btn btn-primary">
           Submit
         </button>
-        <Link to="/users" className="btn btn-default cancel-btn">
+        <Link to="/users" className="btn btn-secondary cancel-btn">
           Cancel
         </Link>
       </div>

--- a/app/components/Users.jsx
+++ b/app/components/Users.jsx
@@ -9,7 +9,7 @@ export default props => {
   let selectUser = props.selectUser
   return (
     <div className="container">
-      <div className="col-xs-12 col-sm-4">
+      <div className="col-12 col-sm-4">
         <h2>All the Cookie Monsters</h2>
         <div id="users" className="list-group">
           {users.map((user, index) => (

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "passport-local": "^1.0.0",
         "pg": "^8.21.0",
         "react": "^18.3.1",
-        "react-bootstrap": "^0.30.7",
         "react-dom": "^18.3.1",
         "react-fontawesome": "^1.5.0",
         "react-redux": "^8.1.3",
@@ -3220,15 +3219,6 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
-    "node_modules/babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
-      "dependencies": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3550,11 +3540,6 @@
         "node": ">=6.0"
       }
     },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
-    },
     "node_modules/clone-deep": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -3773,13 +3758,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -4038,14 +4016,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/dom-helpers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -5963,14 +5933,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
-    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -6499,11 +6461,6 @@
       "engines": {
         "node": ">=4.0"
       }
-    },
-    "node_modules/keycode": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
-      "integrity": "sha512-Rdgz9Hl9Iv4QKi8b0OlCRQEzp4AgVxyCtz5S/+VIHezDmrDhkp2N2TqBWOLz0/gbeREXOOiI9/4b8BY9uw2vFg=="
     },
     "node_modules/keygrip": {
       "version": "1.1.0",
@@ -7871,27 +7828,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-bootstrap": {
-      "version": "0.30.10",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.30.10.tgz",
-      "integrity": "sha512-gcaLHpHc8WGx/0+HQ34GdI8d+bfPQEhU0rf86kmvQWk64tONsIxaEdcTgWeTgmkZGYy4YAfWcf1rsLG+j4UZig==",
-      "dependencies": {
-        "babel-runtime": "^6.11.6",
-        "classnames": "^2.2.5",
-        "dom-helpers": "^3.2.0",
-        "invariant": "^2.2.1",
-        "keycode": "^2.1.2",
-        "prop-types": "^15.5.6",
-        "react-overlays": "^0.6.12",
-        "react-prop-types": "^0.4.0",
-        "uncontrollable": "^4.0.1",
-        "warning": "^3.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=0.14.0",
-        "react-dom": ">=0.14.0"
-      }
-    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -7923,32 +7859,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "node_modules/react-overlays": {
-      "version": "0.6.12",
-      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.6.12.tgz",
-      "integrity": "sha512-+snFq4z05zk11iviZBoCMBiQZOeNni4cXbfpwhcDN5Gxlkb98cg1ZbqNtHooeYBoyozb1AeVZ55FgvMdAJ+O1A==",
-      "dependencies": {
-        "classnames": "^2.2.5",
-        "dom-helpers": "^3.2.0",
-        "react-prop-types": "^0.4.0",
-        "warning": "^3.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=0.14.0",
-        "react-dom": ">=0.14.0"
-      }
-    },
-    "node_modules/react-prop-types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.4.0.tgz",
-      "integrity": "sha512-IyjsJhDX9JkoOV9wlmLaS7z+oxYoIWhfzDcFy7inwoAKTu+VcVNrVpPmLeioJ94y6GeDRsnwarG1py5qofFQMg==",
-      "dependencies": {
-        "warning": "^3.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=0.14.0"
-      }
     },
     "node_modules/react-redux": {
       "version": "8.1.3",
@@ -8133,11 +8043,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -9370,17 +9275,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/uncontrollable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-4.1.0.tgz",
-      "integrity": "sha512-YN1vmvC+UkttgPcFaal2UaNVODu6Rf1FU2x1guyiQRHOzSKkfTJLb0dzhJAEfRsAtjog4PF9UyNWUM2crqDyvg==",
-      "dependencies": {
-        "invariant": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=0.11.0"
-      }
-    },
     "node_modules/undici-types": {
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
@@ -9605,14 +9499,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha512-jMBt6pUrKn5I+OGgtQ4YZLdhIeJmObddh6CsibPxyQ5yPZm1XExSyzC1LCNX7BzhxWgiHmizBWJTHJIjMjTQYQ==",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "homepage": "https://github.com/spmcbride1201/cookie-monsters#readme",
   "dependencies": {
+    "@reduxjs/toolkit": "^2.8.2",
     "axios": "^0.15.2",
     "bcrypt": "^5.1.1",
     "bluebird": "^3.4.7",
@@ -51,10 +52,8 @@
     "passport-local": "^1.0.0",
     "pg": "^8.21.0",
     "react": "^18.3.1",
-    "react-bootstrap": "^0.30.7",
     "react-dom": "^18.3.1",
     "react-fontawesome": "^1.5.0",
-    "@reduxjs/toolkit": "^2.8.2",
     "react-redux": "^8.1.3",
     "react-router-dom": "^6.30.3",
     "redux": "^5.0.1",

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <title>Cookie Monsters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
     <link href="/style.css" rel="stylesheet" />
 


### PR DESCRIPTION
## Summary

- Update CDN from `maxcdn.bootstrapcdn.com/bootstrap/latest` to Bootstrap 5.3.3 via jsDelivr
- Remove unused `react-bootstrap@0.30.7` package (was never imported in any component)
- Migrate all component class names from Bootstrap 3 to Bootstrap 5

**Key migrations:**
| Bootstrap 3 | Bootstrap 5 |
|---|---|
| `navbar-default` | `navbar-expand-lg navbar-light bg-light` |
| `navbar-header` (wrapper div) | removed |
| `navbar-toggle` / `icon-bar` | `navbar-toggler` / `navbar-toggler-icon` |
| `sr-only` | `visually-hidden` |
| `navbar-right` | `ms-auto` |
| collapse `in` class | `show` class |
| `panel` / `panel-heading` / `panel-body` | `card` / `card-header` / `card-body` |
| `thumbnail` / `caption` | `card` / `card-body` |
| `media` / `media-left` / `media-body` | `d-flex gap-3` |
| `jumbotron` | `p-5 mb-4 bg-light rounded-3` |
| `pull-right` | `float-end` |
| `text-right` / `text-left` | `text-end` / `text-start` |
| `col-xs-*` | `col-*` |
| `btn-default` | `btn-secondary` |
| `form-group` | `mb-3` |
| `table-responsive` on `<table>` | wrapper `<div class="table-responsive">` |

## Test plan

- [x] `npm run build` — 0 errors
- [x] `npm test` — 20 passing, 0 failing
- [x] Bootstrap 5.3.3 CDN loads (verified via DOM)
- [x] Products page: 12 cards rendered, no stale `thumbnail`/`panel` classes
- [x] Login → redirects to `/products`, nav shows "Hello, Test1!"
- [x] Navbar toggler: open adds `show` class, close removes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)