### PR TITLE
chore: migrate Font Awesome from CDN to npm

### DIFF
--- a/app/components/Cart.jsx
+++ b/app/components/Cart.jsx
@@ -1,7 +1,8 @@
 'use strict'
 
-import React, { Component } from 'react'
-import Cart from './Cart'
+import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faShoppingCart } from '@fortawesome/free-solid-svg-icons'
 import { Link } from 'react-router-dom'
 
 export default props => {
@@ -14,7 +15,7 @@ export default props => {
   return (
     <div className="float-end">
       <p id="cartPreviewText">
-        <i id="cartPreviewIcon" className="fa fa-shopping-cart"></i>
+        <FontAwesomeIcon id="cartPreviewIcon" icon={faShoppingCart} />
         <span> {numOfItems}</span> items totaling{' '}
         <span>${total.toFixed(2)} </span>
         {window.location.pathname === '/viewcart' ? (

--- a/app/components/Footer.jsx
+++ b/app/components/Footer.jsx
@@ -1,6 +1,8 @@
 'use strict'
 
 import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faGraduationCap } from '@fortawesome/free-solid-svg-icons'
 
 export default () => (
   <div className="footer">
@@ -23,7 +25,7 @@ export default () => (
           Rachel
         </a>
         : the Cookie Monsters of Fullstack Academy{' '}
-        <i className="fa fa-graduation-cap"></i>
+        <FontAwesomeIcon icon={faGraduationCap} />
       </p>
     </div>
   </div>

--- a/app/components/Reviews.jsx
+++ b/app/components/Reviews.jsx
@@ -1,6 +1,8 @@
 'use strict'
 
-import React, { Component } from 'react'
+import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faStar } from '@fortawesome/free-solid-svg-icons'
 import { Link } from 'react-router-dom'
 
 export default () => (
@@ -29,7 +31,7 @@ export default () => (
         {/* STARS - REVIEW TITLE: */}
         {/* Loop over stars to display by rating */}
         <h4>
-          <i className="fa fa-star fa-lg reviewStar" aria-hidden="true"></i>{' '}
+          <FontAwesomeIcon icon={faStar} size="lg" className="reviewStar" />{' '}
           Delicious
         </h4>
         {/* REVIEW BODY by REVIEW.USER */}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^7.2.0",
+        "@fortawesome/free-solid-svg-icons": "^7.2.0",
+        "@fortawesome/react-fontawesome": "^3.3.1",
         "@reduxjs/toolkit": "^2.8.2",
         "axios": "^1.16.1",
         "bcrypt": "^5.1.1",
@@ -27,7 +30,6 @@
         "pg": "^8.21.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-fontawesome": "^1.5.0",
         "react-redux": "^8.1.3",
         "react-router-dom": "^6.30.3",
         "redux": "^5.0.1",
@@ -2106,6 +2108,52 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.2.0.tgz",
+      "integrity": "sha512-IpR0bER9FY25p+e7BmFH25MZKEwFHTfRAfhOyJubgiDnoJNsSvJ7nigLraHtp4VOG/cy8D7uiV0dLkHOne5Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.2.0.tgz",
+      "integrity": "sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.2.0.tgz",
+      "integrity": "sha512-YTVITFGN0/24PxzXrwqCgnyd7njDuzp5ZvaCx5nq/jg55kUYd94Nj8UTchBdBofi/L0nwRfjGOg0E41d2u9T1w==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.3.1.tgz",
+      "integrity": "sha512-wGnAPhfzivDwBWYmEG8MSrEXPruoiMMo48NnsRkj1NZkoaawgOijPNAiSHKMYEoCsqTBSgLTzL6EqTTWGaUR4w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~6 || ~7",
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -8180,6 +8228,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -8336,20 +8385,6 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
-      }
-    },
-    "node_modules/react-fontawesome": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/react-fontawesome/-/react-fontawesome-1.7.1.tgz",
-      "integrity": "sha512-kottReWW1I9Uupub6A5YX4VK7qfpFnEjAcm5zB4Aepst7iofONT27GJYdTcRsj7q5uQu9PXBL7GsxAFKANNUVg==",
-      "dependencies": {
-        "prop-types": "^15.5.6"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "react": ">=0.12.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
   },
   "homepage": "https://github.com/spmcbride1201/cookie-monsters#readme",
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^7.2.0",
+    "@fortawesome/free-solid-svg-icons": "^7.2.0",
+    "@fortawesome/react-fontawesome": "^3.3.1",
     "@reduxjs/toolkit": "^2.8.2",
     "axios": "^1.16.1",
     "bcrypt": "^5.1.1",
@@ -53,7 +56,6 @@
     "pg": "^8.21.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-fontawesome": "^1.5.0",
     "react-redux": "^8.1.3",
     "react-router-dom": "^6.30.3",
     "redux": "^5.0.1",

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,6 @@
     <title>Cookie Monsters</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
     <link href="/style.css" rel="stylesheet" />
 
   </head>


### PR DESCRIPTION
## Summary

- Remove `maxcdn.bootstrapcdn.com/font-awesome/4.7.0` CDN link from `index.html`
- Remove unused `react-fontawesome@1.5.0` package (was never imported; components used raw `<i>` tags)
- Install `@fortawesome/react-fontawesome`, `@fortawesome/fontawesome-svg-core`, `@fortawesome/free-solid-svg-icons`
- Replace the three `<i className="fa fa-*">` tags with `<FontAwesomeIcon>` components:
  - `Cart.jsx` — `fa-shopping-cart` → `faShoppingCart`
  - `Reviews.jsx` — `fa-star fa-lg` → `faStar size="lg"`
  - `Footer.jsx` — `fa-graduation-cap` → `faGraduationCap`
- Icons now ship as inline SVG in the webpack bundle — no external CDN request needed

## Test plan

- [x] `npm run build` — 0 errors
- [x] No Font Awesome CDN `<link>` in page DOM
- [x] Products page: shopping-cart SVG icon renders (`data-icon="cart-shopping"`)
- [x] Reviews page: star SVG icon renders (`data-icon="star"`)
- [x] Footer: graduation-cap SVG icon renders (`data-icon="graduation-cap"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)