### PR TITLE
chore: migrate frontend to TypeScript

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"]
+  "presets": ["@babel/preset-env", "@babel/preset-react", "@babel/preset-typescript"]
 }

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -1,0 +1,22 @@
+import React, { useEffect } from 'react'
+import { useDispatch } from 'react-redux'
+import { Outlet } from 'react-router-dom'
+import axios from 'axios'
+import { receiveProducts } from '../reducers/products'
+import Footer from './Footer'
+import NavContainer from '../containers/NavContainer'
+import type { AppDispatch } from '../store'
+
+export default function App() {
+  const dispatch = useDispatch<AppDispatch>()
+  useEffect(() => {
+    axios.get('/api/products').then(res => dispatch(receiveProducts(res.data)))
+  }, [])
+  return (
+    <div id="main" className="container-fluid">
+      <NavContainer />
+      <Outlet />
+      <Footer />
+    </div>
+  )
+}

--- a/app/components/Cart.tsx
+++ b/app/components/Cart.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faShoppingCart } from '@fortawesome/free-solid-svg-icons'
+import { Link } from 'react-router-dom'
+import type { CartItem } from '../types'
+
+interface CartProps {
+  cart: CartItem[]
+}
+
+export default function Cart({ cart }: CartProps) {
+  let numOfItems = 0
+  let total = 0
+  cart.forEach(cartLineItem => {
+    numOfItems += cartLineItem.quantity
+    total += cartLineItem.product.price * cartLineItem.quantity
+  })
+  return (
+    <div className="float-end">
+      <p id="cartPreviewText">
+        <FontAwesomeIcon id="cartPreviewIcon" icon={faShoppingCart} />
+        <span> {numOfItems}</span> items totaling{' '}
+        <span>${total.toFixed(2)} </span>
+        {window.location.pathname === '/viewcart' ? (
+          <Link className="btn btn-warning btn-sm" to="/products">
+            Buy more
+          </Link>
+        ) : (
+          <Link className="btn btn-success btn-sm" to="/viewcart">
+            View Cart
+          </Link>
+        )}
+      </p>
+    </div>
+  )
+}

--- a/app/components/CartEmpty.tsx
+++ b/app/components/CartEmpty.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+export default function CartEmpty() {
+  return (
+    <div id="cart-empty-container" className="container">
+      <div className="p-5 mb-4 bg-light rounded-3 text-center">
+        <h1>Uh oh!...</h1>
+        <br />
+        <p>You have no cookies in your cart. Add some cookies, ya idiot!</p>
+        <div className="text-center">
+          <p>
+            <a
+              href="/products"
+              className="btn btn-primary btn-lg"
+              role="button"
+            >
+              Go!
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/components/CartLineItem.tsx
+++ b/app/components/CartLineItem.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+
+interface CartLineItemProps {
+  name: string
+  quantity: number
+  photo: string
+  description: string
+  price: number
+}
+
+export default function CartLineItem({ name, quantity, photo, description, price }: CartLineItemProps) {
+  return (
+    <div id="cart-line-item" className="container">
+      <div className="card border-success">
+        <div className="card-header">
+          <div className="row">
+            <div className="col-sm-10 col-9">
+              <h3 className="card-title text-start">{name}</h3>
+            </div>
+            <div className="col-sm-2 col-3 text-end">
+              <button id="remove-from-cart" className="btn btn-sm btn-danger">
+                Remove
+              </button>
+            </div>
+          </div>
+        </div>
+        <div className="card-body">
+          <div className="d-flex gap-3">
+            <div className="thumbContainer">
+              <Link to="/reviews">
+                {' '}
+                <img
+                  className="thumbImg"
+                  src={photo}
+                  alt={name}
+                />
+              </Link>
+            </div>
+            <div>
+              <p>{description}</p>
+              <p>Qty: {quantity}</p>
+              <p>Price: ${(price * quantity).toFixed(2)}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/components/CartView.tsx
+++ b/app/components/CartView.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import Hero from './Hero'
+import CartEmpty from './CartEmpty'
+import CartLineItem from './CartLineItem'
+import type { CartItem } from '../types'
+
+interface CartViewProps {
+  cart: CartItem[]
+  submitOrder: (cart: CartItem[]) => void
+}
+
+export default function CartView({ cart, submitOrder }: CartViewProps) {
+  return (
+    <div id="cart-view" className="container">
+      <Hero />
+      <br />
+      <div className="row">
+        <div className="col-sm-6 col-xs-12">
+          {cart.length < 1 ? (
+            <CartEmpty />
+          ) : (
+            cart.map(item => (
+              <CartLineItem
+                key={item.product.id}
+                name={item.product.name}
+                quantity={item.quantity}
+                photo={item.product.photo}
+                description={item.product.description}
+                price={item.product.price}
+              />
+            ))
+          )}
+        </div>
+      </div>
+      {cart.length > 0 ? (
+        <div className="text-center">
+          <button
+            onClick={evt => {
+              evt.preventDefault()
+              submitOrder(cart)
+            }}
+            className="btn btn-success btn-lg"
+          >
+            Checkout
+          </button>
+        </div>
+      ) : (
+        ''
+      )}
+      <br />
+    </div>
+  )
+}

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faGraduationCap } from '@fortawesome/free-solid-svg-icons'
+
+export default function Footer() {
+  return (
+    <div className="footer">
+      <div className="container">
+        <p className="text-muted">
+          Created by{' '}
+          <a href="http://spmcb.com/" target="_blank" rel="noopener noreferrer">
+            Sean
+          </a>
+          ,{' '}
+          <a
+            href="https://myspace.com/evandigiambattista"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Evan
+          </a>
+          , and{' '}
+          <a href="http://rachelbird.com/" target="_blank" rel="noopener noreferrer">
+            Rachel
+          </a>
+          : the Cookie Monsters of Fullstack Academy{' '}
+          <FontAwesomeIcon icon={faGraduationCap} />
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/app/components/Hero.tsx
+++ b/app/components/Hero.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import Cart from '../containers/CartContainer'
+
+export default function Hero() {
+  return (
+    <div id="headerRow" className="row">
+      <div className="col-sm-6 col-12">
+        <img className="cookieMonsterImg" src="/images/cookie-monster.jpg" />
+        <h1>Cookie Monsters</h1>
+        <h3 className="subtitle">Home of the world&apos;s greatest cookies</h3>
+      </div>
+      <div id="cartRow" className="col-sm-6 col-12">
+        <Cart />
+      </div>
+      <br />
+    </div>
+  )
+}

--- a/app/components/Login.tsx
+++ b/app/components/Login.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+
+interface LoginProps {
+  login: (username: string, password: string) => void
+}
+
+export default function Login({ login }: LoginProps) {
+  return (
+    <div className="container">
+      <h1 className="display-4">Login</h1>
+      <form
+        onSubmit={evt => {
+          evt.preventDefault()
+          const form = evt.currentTarget
+          const username = (form.elements.namedItem('username') as HTMLInputElement).value
+          const password = (form.elements.namedItem('password') as HTMLInputElement).value
+          login(username, password)
+        }}
+      >
+        <input
+          className="form-control auth-field"
+          name="username"
+          placeholder="Username"
+        />
+        <input
+          className="form-control auth-field"
+          name="password"
+          type="password"
+          placeholder="Password"
+        />
+        <input className="btn btn-primary" type="submit" value="Login" />
+      </form>
+    </div>
+  )
+}

--- a/app/components/MyOrders.tsx
+++ b/app/components/MyOrders.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import MyOrdersItem from './MyOrdersItem'
+import type { Order } from '../types'
+
+interface MyOrdersProps {
+  orders: Order[]
+  selectOrder: (order: Partial<Order>) => void
+}
+
+export default function MyOrders({ orders, selectOrder }: MyOrdersProps) {
+  return (
+    <div className="container">
+      <h1 className="display-4">My Orders</h1>
+      {orders.length === 0 ? (
+        <div className="container">
+          <div id="no-orders" className="p-5 mb-4 bg-light rounded-3 text-center">
+            <div>
+              <p>
+                You haven&apos;t placed any orders yet. <br />
+                Get some cookies!
+              </p>
+            </div>
+            <div>
+              <Link to="/products" className="btn btn-primary btn-lg">
+                Go!
+              </Link>
+            </div>
+          </div>
+        </div>
+      ) : (
+        ''
+      )}
+      <div>
+        {orders.map(order => (
+          <MyOrdersItem
+            key={order.id}
+            order={order}
+            selectOrder={selectOrder}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/components/MyOrdersItem.tsx
+++ b/app/components/MyOrdersItem.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import type { Order } from '../types'
+
+interface MyOrdersItemProps {
+  order: Order
+  selectOrder: (order: Partial<Order>) => void
+}
+
+export default function MyOrdersItem({ order, selectOrder }: MyOrdersItemProps) {
+  return (
+    <div className="card border-success mb-3">
+      <div className="card-header">
+        <Link onClick={() => selectOrder(order)} to="/order">
+          <h3 className="card-title">Order ID: {order.id}</h3>
+        </Link>
+      </div>
+      <div className="card-body">
+        <p>Order created {order.created_at}</p>
+        <p>
+          Shipped by{' '}
+          {order.shippingCarrier || 'Omri in a beige Dodge Van'} on
+          January 15, 2017
+        </p>
+        <p>Total: ${order.total}</p>
+      </div>
+    </div>
+  )
+}

--- a/app/components/Nav.tsx
+++ b/app/components/Nav.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from 'react'
+import { Link } from 'react-router-dom'
+import type { User } from '../types'
+
+interface NavProps {
+  auth: User | null
+  logout: () => void
+  selectUser: (user: Partial<User>) => void
+}
+
+export default function Nav({ auth, logout, selectUser }: NavProps) {
+  const [navOpen, setNavOpen] = useState(false)
+  return (
+    <nav className="navbar navbar-expand-lg navbar-light bg-light">
+      <div className="container-fluid">
+        <a className="navbar-brand" href="/products">
+          <img id="brand" alt="Brand" src="/images/brand.png" />
+          <span id="brand-title">Cookie Monsters</span>
+        </a>
+        <button
+          type="button"
+          className={`navbar-toggler${navOpen ? '' : ' collapsed'}`}
+          onClick={() => setNavOpen(open => !open)}
+          aria-expanded={navOpen}
+        >
+          <span className="visually-hidden">Toggle navigation</span>
+          <span className="navbar-toggler-icon" />
+        </button>
+        <div
+          className={`collapse navbar-collapse${navOpen ? ' show' : ''}`}
+          id="bs-example-navbar-collapse-1"
+        >
+          {auth ? (
+            <ul className="navbar-nav ms-auto">
+              <li className="nav-item">
+                <p className="navbar-text">
+                  Hello,{' '}
+                  <a
+                    onClick={evt => {
+                      evt.preventDefault()
+                      selectUser(auth)
+                    }}
+                  >
+                    {auth.name}
+                  </a>
+                  !
+                </p>
+              </li>
+              <li className="nav-item">
+                <Link className="nav-link" to="/myorders">My Orders</Link>
+              </li>
+              {auth.isAdmin ? (
+                <li className="nav-item">
+                  <Link className="nav-link" to="/users">Users</Link>
+                </li>
+              ) : (
+                ''
+              )}
+              <li className="nav-item">
+                <a
+                  className="nav-link"
+                  onClick={evt => {
+                    evt.preventDefault()
+                    logout()
+                  }}
+                >
+                  Logout
+                </a>
+              </li>
+            </ul>
+          ) : (
+            <ul className="navbar-nav ms-auto">
+              <li className="nav-item">
+                <Link className="nav-link" to="/signup">Sign Up</Link>
+              </li>
+              <li className="nav-item">
+                <Link className="nav-link" to="/login">Login</Link>
+              </li>
+            </ul>
+          )}
+        </div>
+      </div>
+    </nav>
+  )
+}

--- a/app/components/Order.tsx
+++ b/app/components/Order.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import type { Order as OrderType } from '../types'
+
+interface OrderProps {
+  order: Partial<OrderType>
+}
+
+export default function Order({ order }: OrderProps) {
+  return (
+    <div className="container">
+      <div>
+        <img className="cookieMonsterImg" src="/images/cookie-monster.jpg" />
+        <h1>Cookie Monsters</h1>
+        <h3 className="subtitle">Home of the world&apos;s greatest cookies</h3>
+      </div>
+      <div id="orderDetail">
+        <p className="lead">Cookie Order {order.id}</p>
+        <div className="table-responsive"><table className="table table-borderless">
+          <thead>
+            <tr>
+              <th>Quantity</th>
+              <th>Cookie</th>
+              <th>Totals</th>
+            </tr>
+          </thead>
+          <tfoot>
+            <tr>
+              <td></td>
+              <td className="float-end orderTableFooterTitles">
+                Flat Shipping Rate
+              </td>
+              <td>${order.shippingRate}</td>
+            </tr>
+            <tr>
+              <td></td>
+              <td className="float-end orderTableFooterTitles">Total</td>
+              <td>${order.total}</td>
+            </tr>
+            <tr>
+              <td></td>
+              <td></td>
+            </tr>
+          </tfoot>
+          <tbody>
+            {order.products?.map(product => (
+              <tr key={product.id}>
+                <td>{product.orderLineItems.quantity}</td>
+                <td>{product.name}</td>
+                <td>$ {product.orderLineItems.subtotal}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table></div>
+        <div className="lead">
+          Cookies shipped by{' '}
+          <span id="shippingCarrier">{order.shippingCarrier}</span>.
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/components/Product.tsx
+++ b/app/components/Product.tsx
@@ -1,0 +1,60 @@
+import React, { useRef } from 'react'
+import { Link } from 'react-router-dom'
+import type { Product as ProductType } from '../types'
+
+interface ProductProps {
+  cookie: ProductType
+  plusItemzToCart: (product: ProductType, quantity: number) => void
+}
+
+export default function Product({ cookie, plusItemzToCart }: ProductProps) {
+  const quantityRef = useRef<HTMLInputElement>(null)
+  return (
+    <div className="col-12 col-sm-6 col-md-3">
+      <div className="card">
+        <div className="cookieContainer">
+          <img className="cookieImage" src={cookie.photo} />
+        </div>
+        <div className="card-body">
+          <h4>
+            {cookie.name === 'Black & White Cookie' ? (
+              <a href="https://www.youtube.com/watch?v=IlLPAIrmqvE">
+                {cookie.name}
+              </a>
+            ) : (
+              cookie.name
+            )}
+          </h4>
+          <p>{cookie.description}</p>
+          <p className="cookieCategory">
+            {cookie.categories.map(category => category).join(', ')}
+          </p>
+          <p>
+            <Link to="/reviews">Reviews</Link>
+          </p>
+          <p>
+            <span id="quantityText">Quantity: </span>
+            <input
+              ref={quantityRef}
+              className="form-control quantity"
+              name="quantity"
+              defaultValue="1"
+            />
+            <a
+              className="btn btn-info btn-sm"
+              role="button"
+              onClick={evt => {
+                evt.preventDefault()
+                const quantity = parseInt(quantityRef.current?.value ?? '1')
+                plusItemzToCart(cookie, quantity)
+                alert(`Added ${quantity} ${cookie.name} to cart`)
+              }}
+            >
+              Add to cart
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/components/Products.tsx
+++ b/app/components/Products.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import Product from './Product'
+import Hero from './Hero'
+import type { Product as ProductType } from '../types'
+
+interface ProductsProps {
+  products: ProductType[]
+  plusItemzToCart: (product: ProductType, quantity: number) => void
+}
+
+export default function Products({ products, plusItemzToCart }: ProductsProps) {
+  return (
+    <div>
+      <div className="container">
+        <Hero />
+        <div className="container">
+          <div className="row">
+            {products.map((cookie, index) => (
+              <Product
+                key={index}
+                cookie={cookie}
+                plusItemzToCart={plusItemzToCart}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/components/Reviews.tsx
+++ b/app/components/Reviews.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faStar } from '@fortawesome/free-solid-svg-icons'
+import { Link } from 'react-router-dom'
+
+export default function Reviews() {
+  return (
+    <div className="container">
+      <div>
+        <Link to="/products">
+          <img className="cookieMonsterImg" src="/images/cookie-monster.jpg" />
+        </Link>
+        <h1>Cookie Monsters</h1>
+        <h3 className="subtitle">Home of the world&apos;s greatest cookies</h3>
+      </div>
+
+      <div id="reviews" className="row">
+        <div className="col-12 col-sm-6 col-md-4">
+          <div className="cookieContainer">
+            <img
+              className="cookieImage"
+              src="/images/cookies/chocolate-chip.jpg"
+            />
+          </div>
+        </div>
+        <div className="col-12 col-sm-6 col-md-8">
+          <h3 id="reviewTitle">Chocolate Chip Cookie</h3>
+          <h4>
+            <FontAwesomeIcon icon={faStar} size="lg" className="reviewStar" />{' '}
+            Delicious
+          </h4>
+          <div className="review">
+            <p className="reviewBody">
+              I&apos;m now fat and an addict. Thanks, Cookie Monsters. Nom nom nom.
+            </p>
+            <p className="reviewUser">submitted by Rachel</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/components/SignUp.tsx
+++ b/app/components/SignUp.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { signup } from '../reducers/auth'
+import type { AppDispatch } from '../store'
+
+interface SignupProps {
+  signup: (username: string, password: string) => void
+}
+
+export const Signup = ({ signup }: SignupProps) => (
+  <div className="container">
+    <h1 className="display-4">Sign Up</h1>
+    <form
+      onSubmit={evt => {
+        evt.preventDefault()
+        const form = evt.currentTarget
+        const username = (form.elements.namedItem('username') as HTMLInputElement).value
+        const password = (form.elements.namedItem('password') as HTMLInputElement).value
+        signup(username, password)
+      }}
+    >
+      <input
+        className="form-control auth-field"
+        name="username"
+        placeholder="Username"
+      />
+      <input
+        className="form-control auth-field"
+        name="password"
+        type="password"
+        placeholder="Password"
+      />
+      <input className="btn btn-primary" type="submit" value="Sign Up" />
+    </form>
+  </div>
+)
+
+function mapDispatchToProps(dispatch: AppDispatch) {
+  return {
+    signup: (username: string, password: string) =>
+      dispatch(signup(username, password)),
+  }
+}
+
+export default connect(null, mapDispatchToProps)(Signup)

--- a/app/components/User.tsx
+++ b/app/components/User.tsx
@@ -1,0 +1,172 @@
+import React from 'react'
+import { Link, Navigate } from 'react-router-dom'
+import type { User as UserType } from '../types'
+
+interface UserProps {
+  user: Partial<UserType>
+  auth: UserType | null
+}
+
+export default function User({ user, auth }: UserProps) {
+  if (!user || !user.name) {
+    return <Navigate to="/login" replace />
+  }
+  return (
+    <div className="container">
+      <div className="col-12 col-sm-4">
+        <h2>{user.name}</h2>
+        <div className="mb-3">
+          <label htmlFor="name">Name</label>
+          <input
+            type="text"
+            className="form-control"
+            id="name"
+            aria-describedby="emailHelp"
+            value={user.name ?? ''}
+            readOnly
+          />
+        </div>
+        <div className="mb-3">
+          <label htmlFor="email">Email address</label>
+          <input
+            type="email"
+            className="form-control"
+            id="email"
+            aria-describedby="emailHelp"
+            value={user.email ?? ''}
+            readOnly
+          />
+          <small id="emailHelp" className="form-text text-muted">
+            We&apos;ll never share your email with anyone else.
+          </small>
+        </div>
+        <h4>Billing Address</h4>
+        <div className="mb-3">
+          <label htmlFor="billingAddress">Address</label>
+          <input
+            type="text"
+            className="form-control"
+            id="billingAddress"
+            value={user.billingAddress ?? ''}
+            readOnly
+          />
+        </div>
+        <div className="mb-3">
+          <label htmlFor="billingCity">City</label>
+          <input
+            type="text"
+            className="form-control"
+            id="billingCity"
+            value={user.billingCity ?? ''}
+            readOnly
+          />
+        </div>
+        <div className="mb-3">
+          <label htmlFor="billingState">State</label>
+          <input
+            type="text"
+            className="form-control"
+            id="billingState"
+            value={user.billingState ?? ''}
+            readOnly
+          />
+        </div>
+        <div className="mb-3">
+          <label htmlFor="billingZip">Zip Code</label>
+          <input
+            type="text"
+            className="form-control"
+            id="billingZip"
+            value={user.billingZip ?? ''}
+            readOnly
+          />
+        </div>
+        <h4>Shipping Address</h4>
+        <div className="mb-3">
+          <label htmlFor="shippingAddress">Address</label>
+          <input
+            type="text"
+            className="form-control"
+            id="shippingAddress"
+            value={user.shippingAddress ?? ''}
+            readOnly
+          />
+        </div>
+        <div className="mb-3">
+          <label htmlFor="shippingCity">City</label>
+          <input
+            type="text"
+            className="form-control"
+            id="shippingCity"
+            value={user.shippingCity ?? ''}
+            readOnly
+          />
+        </div>
+        <div className="mb-3">
+          <label htmlFor="shippingState">State</label>
+          <input
+            type="text"
+            className="form-control"
+            id="shippingState"
+            value={user.shippingState ?? ''}
+            readOnly
+          />
+        </div>
+        <div className="mb-3">
+          <label htmlFor="shippingZip">Zip Code</label>
+          <input
+            type="text"
+            className="form-control"
+            id="shippingZip"
+            value={user.shippingZip ?? ''}
+            readOnly
+          />
+        </div>
+        {auth && auth.isAdmin ? (
+          <fieldset className="mb-3">
+            <legend>
+              {user.name}{' '}
+              {user.isAdmin
+                ? 'is a site administrator'
+                : 'is not a site administrator'}
+            </legend>
+            <div className="form-check">
+              <label className="form-check-label">
+                <input
+                  type="radio"
+                  className="form-check-input"
+                  name="makeAdmin"
+                  id="makeAdmin"
+                  defaultValue="makeAdmin"
+                  disabled={!!user.isAdmin}
+                />
+                Make {user.name} an Administrator
+              </label>
+            </div>
+            <div className="form-check disabled">
+              <label className="form-check-label">
+                <input
+                  type="radio"
+                  className="form-check-input"
+                  name="notAdmin"
+                  id="notAdmin"
+                  defaultValue="notAdmin"
+                  disabled={!user.isAdmin}
+                />
+                Revoke {user.name}&apos;s Administrator rights
+              </label>
+            </div>
+          </fieldset>
+        ) : (
+          ''
+        )}
+        <button type="submit" className="btn btn-primary">
+          Submit
+        </button>
+        <Link to="/users" className="btn btn-secondary cancel-btn">
+          Cancel
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/app/components/Users.tsx
+++ b/app/components/Users.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import type { User as UserType } from '../types'
+
+interface UsersState {
+  users: UserType[]
+  selectedUser: Partial<UserType>
+}
+
+interface UsersProps {
+  users: UsersState
+  auth: UserType | null
+  selectUser: (user: Partial<UserType>) => void
+}
+
+export default function Users({ users, selectUser }: UsersProps) {
+  return (
+    <div className="container">
+      <div className="col-12 col-sm-4">
+        <h2>All the Cookie Monsters</h2>
+        <div id="users" className="list-group">
+          {users.users.map(user => (
+            <li
+              key={user.email}
+              className="list-group-item list-group-item-action"
+            >
+              <a
+                onClick={evt => {
+                  evt.preventDefault()
+                  selectUser(user)
+                }}
+              >
+                {user.name}
+              </a>
+            </li>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/components/WhoAmI.tsx
+++ b/app/components/WhoAmI.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { logout } from '../reducers/auth'
+import type { RootState, AppDispatch } from '../store'
+import type { User } from '../types'
+
+interface WhoAmIProps {
+  user: User | null
+  logout: () => void
+}
+
+export const WhoAmI = ({ user, logout }: WhoAmIProps) => (
+  <div className="whoami">
+    <span className="whoami-user-name">{user && user.name}</span>
+    <button className="logout" onClick={logout}>
+      Logout
+    </button>
+  </div>
+)
+
+function mapStateToProps(state: RootState) {
+  return { user: state.auth }
+}
+
+function mapDispatchToProps(dispatch: AppDispatch) {
+  return { logout: () => dispatch(logout()) }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(WhoAmI)

--- a/app/containers/AppContainer.tsx
+++ b/app/containers/AppContainer.tsx
@@ -1,0 +1,11 @@
+import { connect } from 'react-redux'
+import App from '../components/App'
+import type { RootState } from '../store'
+
+function mapStateToProps(state: RootState) {
+  return {
+    products: state.products,
+  }
+}
+
+export default connect(mapStateToProps)(App)

--- a/app/containers/CartContainer.tsx
+++ b/app/containers/CartContainer.tsx
@@ -1,0 +1,11 @@
+import { connect } from 'react-redux'
+import Cart from '../components/Cart'
+import type { RootState } from '../store'
+
+function mapStateToProps(state: RootState) {
+  return {
+    cart: state.cart,
+  }
+}
+
+export default connect(mapStateToProps)(Cart)

--- a/app/containers/CartViewContainer.tsx
+++ b/app/containers/CartViewContainer.tsx
@@ -1,0 +1,22 @@
+import { connect } from 'react-redux'
+import CartView from '../components/CartView'
+import { submitOrder } from '../reducers/orders'
+import withNavigate, { WithNavigateProps } from '../utils/withNavigate'
+import type { RootState, AppDispatch } from '../store'
+import type { CartItem } from '../types'
+
+function mapStateToProps(state: RootState) {
+  return {
+    cart: state.cart,
+  }
+}
+
+function mapDispatchToProps(dispatch: AppDispatch, ownProps: WithNavigateProps) {
+  return {
+    submitOrder: (cart: CartItem[]) => {
+      dispatch(submitOrder(cart, ownProps.navigate))
+    },
+  }
+}
+
+export default withNavigate(connect(mapStateToProps, mapDispatchToProps)(CartView))

--- a/app/containers/LoginContainer.tsx
+++ b/app/containers/LoginContainer.tsx
@@ -1,0 +1,15 @@
+import { connect } from 'react-redux'
+import Login from '../components/Login'
+import { login } from '../reducers/auth'
+import withNavigate, { WithNavigateProps } from '../utils/withNavigate'
+import type { AppDispatch } from '../store'
+
+function mapDispatchToProps(dispatch: AppDispatch, ownProps: WithNavigateProps) {
+  return {
+    login: (username: string, password: string) => {
+      dispatch(login(username, password)).then(() => ownProps.navigate('/products'))
+    },
+  }
+}
+
+export default withNavigate(connect(null, mapDispatchToProps)(Login))

--- a/app/containers/MyOrdersContainer.tsx
+++ b/app/containers/MyOrdersContainer.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect } from 'react'
+import { connect, useDispatch } from 'react-redux'
+import MyOrders from '../components/MyOrders'
+import { selectOrder, receiveOrders } from '../reducers/orders'
+import type { RootState, AppDispatch } from '../store'
+import type { Order } from '../types'
+
+function mapStateToProps(state: RootState) {
+  return {
+    orders: state.orders.orders,
+  }
+}
+
+function mapDispatchToProps(dispatch: AppDispatch) {
+  return {
+    selectOrder: (order: Partial<Order>) => {
+      dispatch(selectOrder(order))
+    },
+  }
+}
+
+function MyOrdersPage(props: ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>) {
+  const dispatch = useDispatch<AppDispatch>()
+  useEffect(() => {
+    dispatch(receiveOrders())
+  }, [dispatch])
+  return <MyOrders {...props} />
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(MyOrdersPage)

--- a/app/containers/NavContainer.tsx
+++ b/app/containers/NavContainer.tsx
@@ -1,0 +1,28 @@
+import { connect } from 'react-redux'
+import Nav from '../components/Nav'
+import { selectUser } from '../reducers/users'
+import { logout } from '../reducers/auth'
+import withNavigate, { WithNavigateProps } from '../utils/withNavigate'
+import type { RootState, AppDispatch } from '../store'
+import type { User } from '../types'
+
+function mapStateToProps(state: RootState) {
+  return {
+    auth: state.auth,
+  }
+}
+
+function mapDispatchToProps(dispatch: AppDispatch, ownProps: WithNavigateProps) {
+  return {
+    logout: () => {
+      dispatch(logout())
+      ownProps.navigate('/')
+    },
+    selectUser: (user: Partial<User>) => {
+      dispatch(selectUser(user))
+      ownProps.navigate('/user')
+    },
+  }
+}
+
+export default withNavigate(connect(mapStateToProps, mapDispatchToProps)(Nav))

--- a/app/containers/OrderContainer.tsx
+++ b/app/containers/OrderContainer.tsx
@@ -1,0 +1,11 @@
+import { connect } from 'react-redux'
+import Order from '../components/Order'
+import type { RootState } from '../store'
+
+function mapStateToProps(state: RootState) {
+  return {
+    order: state.orders.selectedOrder,
+  }
+}
+
+export default connect(mapStateToProps)(Order)

--- a/app/containers/ProductsContainer.tsx
+++ b/app/containers/ProductsContainer.tsx
@@ -1,0 +1,21 @@
+import { connect } from 'react-redux'
+import Products from '../components/Products'
+import { addToCart } from '../reducers/cart'
+import type { RootState, AppDispatch } from '../store'
+import type { Product } from '../types'
+
+function mapStateToProps(state: RootState) {
+  return {
+    products: state.products,
+  }
+}
+
+function mapDispatchToProps(dispatch: AppDispatch) {
+  return {
+    plusItemzToCart: (product: Product, quantity: number) => {
+      dispatch(addToCart(product, quantity))
+    },
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Products)

--- a/app/containers/UserContainer.tsx
+++ b/app/containers/UserContainer.tsx
@@ -1,0 +1,12 @@
+import { connect } from 'react-redux'
+import User from '../components/User'
+import type { RootState } from '../store'
+
+function mapStateToProps(state: RootState) {
+  return {
+    user: state.users.selectedUser,
+    auth: state.auth,
+  }
+}
+
+export default connect(mapStateToProps)(User)

--- a/app/containers/UsersContainer.tsx
+++ b/app/containers/UsersContainer.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect } from 'react'
+import { connect, useDispatch } from 'react-redux'
+import Users from '../components/Users'
+import { selectUser, receiveUsers } from '../reducers/users'
+import withNavigate, { WithNavigateProps } from '../utils/withNavigate'
+import type { RootState, AppDispatch } from '../store'
+import type { User } from '../types'
+
+function mapStateToProps(state: RootState) {
+  return {
+    users: state.users,
+    auth: state.auth,
+  }
+}
+
+function mapDispatchToProps(dispatch: AppDispatch, ownProps: WithNavigateProps) {
+  return {
+    selectUser: (user: Partial<User>) => {
+      dispatch(selectUser(user))
+      ownProps.navigate('/user')
+    },
+  }
+}
+
+function UsersPage(props: ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>) {
+  const dispatch = useDispatch<AppDispatch>()
+  useEffect(() => {
+    dispatch(receiveUsers())
+  }, [dispatch])
+  return <Users {...props} />
+}
+
+export default withNavigate(connect(mapStateToProps, mapDispatchToProps)(UsersPage))

--- a/app/hooks.ts
+++ b/app/hooks.ts
@@ -1,0 +1,5 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
+import type { RootState, AppDispatch } from './store'
+
+export const useAppDispatch = () => useDispatch<AppDispatch>()
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector

--- a/app/main.tsx
+++ b/app/main.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { Provider } from 'react-redux'
+import store from './store'
+
+import AppContainer from './containers/AppContainer'
+import CartViewContainer from './containers/CartViewContainer'
+import LoginContainer from './containers/LoginContainer'
+import SignUp from './components/SignUp'
+import Order from './containers/OrderContainer'
+import MyOrders from './containers/MyOrdersContainer'
+import ProductsContainer from './containers/ProductsContainer'
+import UserContainer from './containers/UserContainer'
+import UsersContainer from './containers/UsersContainer'
+import Reviews from './components/Reviews'
+
+const rootEl = document.getElementById('main')
+if (!rootEl) throw new Error('Root element #main not found')
+
+createRoot(rootEl).render(
+  <Provider store={store}>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<AppContainer />}>
+          <Route index element={<Navigate to="/products" replace />} />
+          <Route path="products" element={<ProductsContainer />} />
+          <Route path="viewcart" element={<CartViewContainer />} />
+          <Route path="order" element={<Order />} />
+          <Route path="reviews" element={<Reviews />} />
+          <Route path="signup" element={<SignUp />} />
+          <Route path="login" element={<LoginContainer />} />
+          <Route path="users" element={<UsersContainer />} />
+          <Route path="user" element={<UserContainer />} />
+          <Route path="myorders" element={<MyOrders />} />
+        </Route>
+      </Routes>
+    </BrowserRouter>
+  </Provider>
+)

--- a/app/reducers/auth.ts
+++ b/app/reducers/auth.ts
@@ -1,0 +1,42 @@
+import { createSlice, createAction, PayloadAction } from '@reduxjs/toolkit'
+import axios from 'axios'
+import type { AppDispatch } from '../store'
+import type { User } from '../types'
+
+export const wipeLocalState = createAction('auth/wipeLocalState')
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState: null as User | null,
+  reducers: {
+    authenticated: (_state, action: PayloadAction<User | null>) => action.payload,
+  },
+})
+
+export const { authenticated } = authSlice.actions
+
+export const whoami = () => (dispatch: AppDispatch) =>
+  axios
+    .get('/api/auth/whoami')
+    .then(response => dispatch(authenticated(response.data)))
+    .catch(() => dispatch(authenticated(null)))
+
+export const login = (username: string, password: string) => (dispatch: AppDispatch) =>
+  axios
+    .post('/api/auth/local/login', { username, password })
+    .then(() => dispatch(whoami()))
+    .catch(() => dispatch(whoami()))
+
+export const signup = (username: string, password: string) => (dispatch: AppDispatch) =>
+  axios
+    .post('/api/auth/local/signup', { username, password })
+    .then(() => dispatch(whoami()))
+    .catch(() => dispatch(whoami()))
+
+export const logout = () => (dispatch: AppDispatch) =>
+  axios
+    .post('/api/auth/logout')
+    .then(() => { dispatch(whoami()); dispatch(wipeLocalState()) })
+    .catch(() => { dispatch(whoami()); dispatch(wipeLocalState()) })
+
+export default authSlice.reducer

--- a/app/reducers/cart.ts
+++ b/app/reducers/cart.ts
@@ -1,0 +1,38 @@
+import { createSlice, current, PayloadAction } from '@reduxjs/toolkit'
+import { wipeLocalState } from './auth'
+import type { CartItem, Product } from '../types'
+
+const cartSlice = createSlice({
+  name: 'cart',
+  initialState: JSON.parse(localStorage.getItem('cart') || '[]') as CartItem[],
+  reducers: {
+    addToCart: {
+      reducer(state, action: PayloadAction<{ product: Product; quantity: number }>) {
+        const { product, quantity } = action.payload
+        const existing = state.find(item => item.product.id === product.id)
+        if (existing) {
+          existing.quantity += quantity
+        } else {
+          state.push({ product, quantity })
+        }
+        localStorage.setItem('cart', JSON.stringify(current(state)))
+      },
+      prepare(product: Product, quantity: number) {
+        return { payload: { product, quantity } }
+      },
+    },
+    emptyCart(): CartItem[] {
+      localStorage.removeItem('cart')
+      return []
+    },
+  },
+  extraReducers: builder => {
+    builder.addCase(wipeLocalState, (): CartItem[] => {
+      localStorage.removeItem('cart')
+      return []
+    })
+  },
+})
+
+export const { addToCart, emptyCart } = cartSlice.actions
+export default cartSlice.reducer

--- a/app/reducers/index.ts
+++ b/app/reducers/index.ts
@@ -1,0 +1,8 @@
+import { combineReducers } from '@reduxjs/toolkit'
+import auth from './auth'
+import products from './products'
+import cart from './cart'
+import users from './users'
+import orders from './orders'
+
+export default combineReducers({ auth, products, cart, users, orders })

--- a/app/reducers/orders.ts
+++ b/app/reducers/orders.ts
@@ -1,0 +1,47 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import axios from 'axios'
+import { emptyCart } from './cart'
+import type { AppDispatch } from '../store'
+import type { CartItem, Order } from '../types'
+import type { NavigateFunction } from 'react-router-dom'
+
+interface OrdersState {
+  orders: Order[]
+  selectedOrder: Partial<Order>
+}
+
+const ordersSlice = createSlice({
+  name: 'orders',
+  initialState: { orders: [], selectedOrder: {} } as OrdersState,
+  reducers: {
+    setOrders: (state, action: PayloadAction<Order[]>) => { state.orders = action.payload },
+    selectOrder: (state, action: PayloadAction<Partial<Order>>) => { state.selectedOrder = action.payload },
+  },
+})
+
+export const { selectOrder } = ordersSlice.actions
+
+export const receiveOrders = () => (dispatch: AppDispatch) =>
+  axios
+    .get('/api/orders/')
+    .then(res => dispatch(ordersSlice.actions.setOrders(res.data)))
+    .catch(err => console.error(err))
+
+export function submitOrder(cart: CartItem[], navigate?: NavigateFunction) {
+  const orderLineItems: Record<number, { quantity: number }> = {}
+  cart.forEach(item => {
+    orderLineItems[item.product.id] = { quantity: item.quantity }
+  })
+  const order = { shippingCarrier: 'UPS', orderLineItems }
+  return (dispatch: AppDispatch) =>
+    axios
+      .post('/api/orders/', order)
+      .then(() => {
+        alert('Cookies are on the way!')
+        dispatch(emptyCart())
+        navigate && navigate('/myorders')
+      })
+      .catch(err => alert(err))
+}
+
+export default ordersSlice.reducer

--- a/app/reducers/products.ts
+++ b/app/reducers/products.ts
@@ -1,0 +1,13 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import type { Product } from '../types'
+
+const productsSlice = createSlice({
+  name: 'products',
+  initialState: [] as Product[],
+  reducers: {
+    receiveProducts: (_state, action: PayloadAction<Product[]>) => action.payload,
+  },
+})
+
+export const { receiveProducts } = productsSlice.actions
+export default productsSlice.reducer

--- a/app/reducers/users.ts
+++ b/app/reducers/users.ts
@@ -1,0 +1,34 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import axios from 'axios'
+import { wipeLocalState } from './auth'
+import type { AppDispatch } from '../store'
+import type { User } from '../types'
+
+interface UsersState {
+  users: User[]
+  selectedUser: Partial<User>
+}
+
+const initialState: UsersState = { users: [], selectedUser: {} }
+
+const usersSlice = createSlice({
+  name: 'users',
+  initialState,
+  reducers: {
+    setUsers: (state, action: PayloadAction<User[]>) => { state.users = action.payload },
+    selectUser: (state, action: PayloadAction<Partial<User>>) => { state.selectedUser = action.payload },
+  },
+  extraReducers: builder => {
+    builder.addCase(wipeLocalState, () => initialState)
+  },
+})
+
+export const { selectUser } = usersSlice.actions
+
+export const receiveUsers = () => (dispatch: AppDispatch) =>
+  axios
+    .get('/api/users/')
+    .then(res => dispatch(usersSlice.actions.setUsers(res.data)))
+    .catch(err => console.error(err))
+
+export default usersSlice.reducer

--- a/app/store.ts
+++ b/app/store.ts
@@ -1,0 +1,17 @@
+import { configureStore } from '@reduxjs/toolkit'
+import rootReducer from './reducers'
+import { createLogger } from 'redux-logger'
+import { whoami } from './reducers/auth'
+
+const store = configureStore({
+  reducer: rootReducer,
+  middleware: getDefaultMiddleware =>
+    getDefaultMiddleware().concat(createLogger()),
+})
+
+store.dispatch(whoami())
+
+export type RootState = ReturnType<typeof store.getState>
+export type AppDispatch = typeof store.dispatch
+
+export default store

--- a/app/types.ts
+++ b/app/types.ts
@@ -1,0 +1,42 @@
+export interface Product {
+  id: number
+  name: string
+  description: string
+  price: number
+  photo: string
+  categories: string[]
+}
+
+export interface CartItem {
+  product: Product
+  quantity: number
+}
+
+export interface User {
+  id: number
+  name: string
+  email: string
+  isAdmin: boolean
+  billingAddress?: string
+  billingCity?: string
+  billingState?: string
+  billingZip?: string
+  shippingAddress?: string
+  shippingCity?: string
+  shippingState?: string
+  shippingZip?: string
+}
+
+export interface OrderLineItem {
+  quantity: number
+  subtotal?: number
+}
+
+export interface Order {
+  id: number
+  shippingCarrier?: string
+  shippingRate?: number
+  total?: number
+  created_at?: string
+  products: (Product & { orderLineItems: OrderLineItem })[]
+}

--- a/app/utils/withNavigate.tsx
+++ b/app/utils/withNavigate.tsx
@@ -1,0 +1,15 @@
+import React, { ComponentType } from 'react'
+import { useNavigate, NavigateFunction } from 'react-router-dom'
+
+export interface WithNavigateProps {
+  navigate: NavigateFunction
+}
+
+export default function withNavigate<P extends WithNavigateProps>(
+  Component: ComponentType<P>
+): ComponentType<Omit<P, keyof WithNavigateProps>> {
+  return function WithNavigate(props: Omit<P, keyof WithNavigateProps>) {
+    const navigate = useNavigate()
+    return <Component {...(props as P)} navigate={navigate} />
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,8 +40,14 @@
         "@babel/core": "^7.29.7",
         "@babel/preset-env": "^7.29.7",
         "@babel/preset-react": "^7.29.7",
+        "@babel/preset-typescript": "^7.29.7",
         "@babel/register": "^7.29.7",
         "@cfaester/enzyme-adapter-react-18": "^0.8.0",
+        "@types/node": "^25.9.1",
+        "@types/react": "^19.2.15",
+        "@types/react-dom": "^19.2.3",
+        "@types/react-redux": "^7.1.34",
+        "@types/redux-logger": "^3.0.13",
         "ajv": "^8.20.0",
         "babel-loader": "^9.2.1",
         "chai": "^4.5.0",
@@ -56,6 +62,7 @@
         "sinon": "^19.0.5",
         "sinon-chai": "^3.7.0",
         "supertest": "^7.2.2",
+        "typescript": "^6.0.3",
         "volleyball": "^1.4.1",
         "webpack": "^5.107.2",
         "webpack-cli": "^5.1.4"
@@ -719,6 +726,22 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
       "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1606,6 +1629,26 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
+      "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/plugin-syntax-typescript": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.29.7.tgz",
@@ -1787,6 +1830,26 @@
         "@babel/plugin-transform-react-jsx": "^7.29.7",
         "@babel/plugin-transform-react-jsx-development": "^7.29.7",
         "@babel/plugin-transform-react-pure-annotations": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.29.7.tgz",
+      "integrity": "sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "@babel/plugin-syntax-jsx": "^7.29.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.29.7",
+        "@babel/plugin-transform-typescript": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2521,6 +2584,59 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.34",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.34.tgz",
+      "integrity": "sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
+      }
+    },
+    "node_modules/@types/react-redux/node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/@types/redux-logger": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@types/redux-logger/-/redux-logger-3.0.13.tgz",
+      "integrity": "sha512-jylqZXQfMxahkuPcO8J12AKSSCQngdEWQrw7UiLUJzMBcv1r4Qg77P6mjGLjM27e5gFQDPD8vwUMJ9AyVxFSsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/@types/use-sync-external-store": {
@@ -4071,6 +4187,13 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -9873,6 +9996,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/uid2": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lint": "eslint app/ server/ db/ index.js",
     "lint:fix": "eslint --fix app/ server/ db/ index.js",
     "format": "prettier --write app/ server/ db/ index.js",
-    "format:check": "prettier --check app/ server/ db/ index.js"
+    "format:check": "prettier --check app/ server/ db/ index.js",
+    "typecheck": "tsc --noEmit"
   },
   "repository": {
     "type": "git",
@@ -66,8 +67,14 @@
     "@babel/core": "^7.29.7",
     "@babel/preset-env": "^7.29.7",
     "@babel/preset-react": "^7.29.7",
+    "@babel/preset-typescript": "^7.29.7",
     "@babel/register": "^7.29.7",
     "@cfaester/enzyme-adapter-react-18": "^0.8.0",
+    "@types/node": "^25.9.1",
+    "@types/react": "^19.2.15",
+    "@types/react-dom": "^19.2.3",
+    "@types/react-redux": "^7.1.34",
+    "@types/redux-logger": "^3.0.13",
     "ajv": "^8.20.0",
     "babel-loader": "^9.2.1",
     "chai": "^4.5.0",
@@ -82,6 +89,7 @@
     "sinon": "^19.0.5",
     "sinon-chai": "^3.7.0",
     "supertest": "^7.2.2",
+    "typescript": "^6.0.3",
     "volleyball": "^1.4.1",
     "webpack": "^5.107.2",
     "webpack-cli": "^5.1.4"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "module": "ESNext",
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react"
+  },
+  "include": ["app/**/*"],
+  "exclude": ["node_modules", "**/*.test.jsx"]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,19 +4,19 @@ const path = require('path')
 
 module.exports = {
   mode: 'development',
-  entry: './app/main.jsx',
+  entry: './app/main.tsx',
   output: {
     path: path.join(__dirname, 'public'),
     filename: 'bundle.js',
   },
   devtool: 'source-map',
   resolve: {
-    extensions: ['.js', '.jsx'],
+    extensions: ['.ts', '.tsx', '.js', '.jsx'],
   },
   module: {
     rules: [
       {
-        test: /\.jsx?$/,
+        test: /\.[jt]sx?$/,
         exclude: /node_modules/,
         use: 'babel-loader',
       },


### PR DESCRIPTION
## Summary

- Add `tsconfig.json` with strict mode, `isolatedModules: true`, and `moduleResolution: bundler` (required for TypeScript 6)
- Add `@babel/preset-typescript` to `.babelrc`; update webpack entry point and `resolve.extensions` to include `.ts`/`.tsx`
- Install `@types/redux-logger`; add `typecheck` script (`tsc --noEmit`)
- Create `app/types.ts` — shared domain interfaces: `Product`, `CartItem`, `User`, `Order`, `OrderLineItem`
- Create `app/hooks.ts` — typed `useAppDispatch` / `useAppSelector` hooks
- Convert all 37 app source files from `.jsx`/`.js` to `.tsx`/`.ts` (leaving `WhoAmI.test.jsx` as-is)
- All reducers typed with `PayloadAction`; `withNavigate` HOC typed as a generic `<P extends WithNavigateProps>`
- `auth.ts`/`users.ts`/`orders.ts` reference `AppDispatch` via `import type` to break the store circular dependency

## Test plan

- [ ] `npm run typecheck` exits 0 (zero type errors)
- [ ] `npm run build` exits 0 (webpack compiles cleanly, 0 errors)
- [ ] `npm test` — all 20 tests pass, 7 pending (no regressions)
- [ ] Smoke test the running app: products load, cart works, login/signup flow works

🤖 Generated with [Claude Code](https://claude.com/claude-code)