### PR TITLE
feat: remove from cart, conditional checkout, and component tests

### DIFF
--- a/app/components/Cart.test.jsx
+++ b/app/components/Cart.test.jsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import { MemoryRouter } from 'react-router-dom'
+import Cart from './Cart'
+
+describe('<Cart/>', () => {
+  it('shows 0 items and $0.00 when cart is empty', () => {
+    const root = shallow(
+      <MemoryRouter>
+        <Cart cart={[]} />
+      </MemoryRouter>
+    )
+    expect(root.html()).to.contain('0')
+    expect(root.html()).to.contain('$0.00')
+  })
+
+  it('shows correct item count and total for one item', () => {
+    const cart = [
+      {
+        product: { id: 1, name: 'Chocolate Chip', price: 1.5, photo: '', description: '', categories: [] },
+        quantity: 2,
+      },
+    ]
+    const root = shallow(
+      <MemoryRouter>
+        <Cart cart={cart} />
+      </MemoryRouter>
+    )
+    expect(root.html()).to.contain('2')
+    expect(root.html()).to.contain('$3.00')
+  })
+
+  it('accumulates totals across multiple items', () => {
+    const cart = [
+      {
+        product: { id: 1, name: 'Chocolate Chip', price: 1.5, photo: '', description: '', categories: [] },
+        quantity: 2,
+      },
+      {
+        product: { id: 2, name: 'Oatmeal Raisin', price: 2.0, photo: '', description: '', categories: [] },
+        quantity: 1,
+      },
+    ]
+    const root = shallow(
+      <MemoryRouter>
+        <Cart cart={cart} />
+      </MemoryRouter>
+    )
+    // 2 + 1 = 3 items, 2*1.5 + 1*2.0 = $5.00
+    expect(root.html()).to.contain('3')
+    expect(root.html()).to.contain('$5.00')
+  })
+})

--- a/app/components/CartLineItem.tsx
+++ b/app/components/CartLineItem.tsx
@@ -7,9 +7,10 @@ interface CartLineItemProps {
   photo: string
   description: string
   price: number
+  onRemove: () => void
 }
 
-export default function CartLineItem({ name, quantity, photo, description, price }: CartLineItemProps) {
+export default function CartLineItem({ name, quantity, photo, description, price, onRemove }: CartLineItemProps) {
   return (
     <div id="cart-line-item" className="container">
       <div className="card border-success">
@@ -19,7 +20,11 @@ export default function CartLineItem({ name, quantity, photo, description, price
               <h3 className="card-title text-start">{name}</h3>
             </div>
             <div className="col-sm-2 col-3 text-end">
-              <button id="remove-from-cart" className="btn btn-sm btn-danger">
+              <button
+                id="remove-from-cart"
+                className="btn btn-sm btn-danger"
+                onClick={evt => { evt.preventDefault(); onRemove() }}
+              >
                 Remove
               </button>
             </div>

--- a/app/components/CartView.tsx
+++ b/app/components/CartView.tsx
@@ -2,14 +2,17 @@ import React from 'react'
 import Hero from './Hero'
 import CartEmpty from './CartEmpty'
 import CartLineItem from './CartLineItem'
-import type { CartItem } from '../types'
+import type { CartItem, User } from '../types'
 
 interface CartViewProps {
   cart: CartItem[]
+  auth: User | null
   submitOrder: (cart: CartItem[]) => void
+  removeFromCart: (productId: number) => void
+  navigateToLogin: () => void
 }
 
-export default function CartView({ cart, submitOrder }: CartViewProps) {
+export default function CartView({ cart, auth, submitOrder, removeFromCart, navigateToLogin }: CartViewProps) {
   return (
     <div id="cart-view" className="container">
       <Hero />
@@ -27,6 +30,7 @@ export default function CartView({ cart, submitOrder }: CartViewProps) {
                 photo={item.product.photo}
                 description={item.product.description}
                 price={item.product.price}
+                onRemove={() => removeFromCart(item.product.id)}
               />
             ))
           )}
@@ -37,11 +41,15 @@ export default function CartView({ cart, submitOrder }: CartViewProps) {
           <button
             onClick={evt => {
               evt.preventDefault()
-              submitOrder(cart)
+              if (!auth) {
+                navigateToLogin()
+              } else {
+                submitOrder(cart)
+              }
             }}
             className="btn btn-success btn-lg"
           >
-            Checkout
+            {auth ? 'Checkout' : 'Log in to checkout'}
           </button>
         </div>
       ) : (

--- a/app/components/Nav.test.jsx
+++ b/app/components/Nav.test.jsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import { MemoryRouter } from 'react-router-dom'
+import Nav from './Nav'
+
+describe('<Nav/>', () => {
+  const noop = () => {}
+
+  describe('when logged out', () => {
+    let root
+    beforeEach(() => {
+      root = shallow(
+        <MemoryRouter>
+          <Nav auth={null} logout={noop} selectUser={noop} />
+        </MemoryRouter>
+      )
+    })
+
+    it('shows Sign Up link', () => {
+      expect(root.html()).to.contain('Sign Up')
+    })
+
+    it('shows Login link', () => {
+      expect(root.html()).to.contain('Login')
+    })
+
+    it('does not show Logout', () => {
+      expect(root.html()).to.not.contain('Logout')
+    })
+  })
+
+  describe('when logged in as a regular user', () => {
+    const user = { id: 1, name: 'Rachel', email: 'rachel@example.com', isAdmin: false }
+    let root
+    beforeEach(() => {
+      root = shallow(
+        <MemoryRouter>
+          <Nav auth={user} logout={noop} selectUser={noop} />
+        </MemoryRouter>
+      )
+    })
+
+    it('greets the user by name', () => {
+      expect(root.html()).to.contain('Rachel')
+    })
+
+    it('shows Logout', () => {
+      expect(root.html()).to.contain('Logout')
+    })
+
+    it('does not show Users link (not admin)', () => {
+      expect(root.html()).to.not.contain('>Users<')
+    })
+  })
+
+  describe('when logged in as admin', () => {
+    const admin = { id: 2, name: 'Evan', email: 'evan@example.com', isAdmin: true }
+    let root
+    beforeEach(() => {
+      root = shallow(
+        <MemoryRouter>
+          <Nav auth={admin} logout={noop} selectUser={noop} />
+        </MemoryRouter>
+      )
+    })
+
+    it('shows Users link for admin', () => {
+      expect(root.html()).to.contain('Users')
+    })
+  })
+})

--- a/app/components/Products.test.jsx
+++ b/app/components/Products.test.jsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import { MemoryRouter } from 'react-router-dom'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import Products from './Products'
+import rootReducer from '../reducers'
+
+// Minimal store for component tests — no middleware, no side effects
+function makeTestStore() {
+  return configureStore({ reducer: rootReducer })
+}
+
+describe('<Products/>', () => {
+  const noop = () => {}
+  const sampleProducts = [
+    { id: 1, name: 'Chocolate Chip', description: 'Classic', price: 1.5, photo: 'cc.jpg', categories: ['chocolate'] },
+    { id: 2, name: 'Oatmeal Raisin', description: 'Why?', price: 1.25, photo: 'or.jpg', categories: ['oatmeal'] },
+    { id: 3, name: 'Sugar Cookie', description: 'Sweet', price: 1.0, photo: 'sc.jpg', categories: ['classic'] },
+  ]
+
+  it('renders a card for each product', () => {
+    const root = shallow(
+      <Provider store={makeTestStore()}>
+        <MemoryRouter>
+          <Products products={sampleProducts} plusItemzToCart={noop} />
+        </MemoryRouter>
+      </Provider>
+    )
+    expect(root.html()).to.contain('Chocolate Chip')
+    expect(root.html()).to.contain('Oatmeal Raisin')
+    expect(root.html()).to.contain('Sugar Cookie')
+  })
+
+  it('renders nothing for an empty product list', () => {
+    const root = shallow(
+      <Provider store={makeTestStore()}>
+        <MemoryRouter>
+          <Products products={[]} plusItemzToCart={noop} />
+        </MemoryRouter>
+      </Provider>
+    )
+    expect(root.html()).to.not.contain('Add to cart')
+  })
+
+  it('shows category tags for each product', () => {
+    const root = shallow(
+      <Provider store={makeTestStore()}>
+        <MemoryRouter>
+          <Products products={sampleProducts} plusItemzToCart={noop} />
+        </MemoryRouter>
+      </Provider>
+    )
+    expect(root.html()).to.contain('chocolate')
+    expect(root.html()).to.contain('oatmeal')
+  })
+})

--- a/app/containers/CartViewContainer.tsx
+++ b/app/containers/CartViewContainer.tsx
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux'
 import CartView from '../components/CartView'
 import { submitOrder } from '../reducers/orders'
+import { removeFromCart } from '../reducers/cart'
 import withNavigate, { WithNavigateProps } from '../utils/withNavigate'
 import type { RootState, AppDispatch } from '../store'
 import type { CartItem } from '../types'
@@ -8,6 +9,7 @@ import type { CartItem } from '../types'
 function mapStateToProps(state: RootState) {
   return {
     cart: state.cart,
+    auth: state.auth,
   }
 }
 
@@ -15,6 +17,12 @@ function mapDispatchToProps(dispatch: AppDispatch, ownProps: WithNavigateProps) 
   return {
     submitOrder: (cart: CartItem[]) => {
       dispatch(submitOrder(cart, ownProps.navigate))
+    },
+    removeFromCart: (productId: number) => {
+      dispatch(removeFromCart(productId))
+    },
+    navigateToLogin: () => {
+      ownProps.navigate('/login')
     },
   }
 }

--- a/app/reducers/cart.ts
+++ b/app/reducers/cart.ts
@@ -21,6 +21,11 @@ const cartSlice = createSlice({
         return { payload: { product, quantity } }
       },
     },
+    removeFromCart(state, action: PayloadAction<number>) {
+      const next = state.filter(item => item.product.id !== action.payload)
+      localStorage.setItem('cart', JSON.stringify(next))
+      return next
+    },
     emptyCart(): CartItem[] {
       localStorage.removeItem('cart')
       return []
@@ -34,5 +39,5 @@ const cartSlice = createSlice({
   },
 })
 
-export const { addToCart, emptyCart } = cartSlice.actions
+export const { addToCart, removeFromCart, emptyCart } = cartSlice.actions
 export default cartSlice.reducer

--- a/test-setup.js
+++ b/test-setup.js
@@ -2,3 +2,15 @@ const Enzyme = require('enzyme')
 const Adapter = require('@cfaester/enzyme-adapter-react-18').default
 
 Enzyme.configure({ adapter: new Adapter() })
+
+// Minimal browser globals for component tests running in Node
+if (typeof window === 'undefined') {
+  global.window = { location: { pathname: '/' } }
+}
+if (typeof localStorage === 'undefined') {
+  global.localStorage = {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  }
+}


### PR DESCRIPTION
## Summary

- **#158 Remove from cart**: adds `removeFromCart(productId)` to the cart reducer, wires it through `CartViewContainer`, and hooks up the Remove button in `CartLineItem`
- **#161 Conditional checkout**: passes `auth` state to `CartView`; unauthenticated users see "Log in to checkout" and are redirected to `/login` instead of hitting the API
- **#153/#154/#155 Component tests**: 13 new enzyme tests covering `Cart`, `Nav`, and `Products` components; adds minimal `window`/`localStorage` stubs to `test-setup.js` for the Node test environment

## Test plan

- [ ] `npm run typecheck` exits 0
- [ ] `npm run build` exits 0
- [ ] `npm test` — 33 passing, 7 pending, 0 failing
- [ ] Visit `/viewcart` with an item in the cart — Remove button removes item from cart and localStorage
- [ ] Click checkout when logged out — button reads "Log in to checkout" and redirects to `/login`
- [ ] Click checkout when logged in — order submits and redirects to `/myorders`

🤖 Generated with [Claude Code](https://claude.com/claude-code)