### PR TITLE
fix: remove destructive postinstall seed and require SESSION_SECRET

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "start[prod]": "check-node-version --node '>= 10.15.3' && node server/start.js",
     "start": "check-node-version --node '>= 10.15.3' && npm run start[prod]",
     "seed": "node db/seed.js",
-    "postinstall": "npm run build && node db/seed.js",
+    "postinstall": "npm run build",
     "lint": "eslint app/ server/ db/ index.js",
     "lint:fix": "eslint --fix app/ server/ db/ index.js",
     "format": "prettier --write app/ server/ db/ index.js",

--- a/server/start.js
+++ b/server/start.js
@@ -19,7 +19,13 @@ module.exports = app
   .use(
     require('cookie-session')({
       name: 'session',
-      keys: [process.env.SESSION_SECRET || 'an insecure secret key'],
+      keys: [
+      (() => {
+        if (!process.env.SESSION_SECRET)
+          throw new Error('SESSION_SECRET environment variable is required')
+        return process.env.SESSION_SECRET
+      })(),
+    ],
     })
   )
 

--- a/test-setup.js
+++ b/test-setup.js
@@ -1,3 +1,5 @@
+process.env.SESSION_SECRET = 'test-session-secret'
+
 const Enzyme = require('enzyme')
 const Adapter = require('@cfaester/enzyme-adapter-react-18').default
 


### PR DESCRIPTION
Fixes #177. Fixes #178.

## Summary
- **#177** — [`package.json:18`](package.json) removes `node db/seed.js` from `postinstall`; `npm install` no longer drops and recreates all tables. Seeding remains available via the existing `npm run seed` command.
- **#178** — [`server/start.js:22`](server/start.js) throws on startup if `SESSION_SECRET` is unset instead of silently falling back to the hardcoded public key `'an insecure secret key'`, preventing session cookie forgery. [`test-setup.js:1`](test-setup.js) sets a test-only value so the test suite keeps working.

## Test plan
- [x] All 37 existing tests pass
- [x] `npm install` completes without connecting to Postgres or wiping data
- [x] `npm run seed` still seeds the database as expected
- [x] Starting the server without `SESSION_SECRET` throws immediately with a clear error message
- [x] Starting the server with `SESSION_SECRET` set proceeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)