### PR TITLE
docs: add .env.example and Project Setup guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Required
+SESSION_SECRET=change-me-to-a-long-random-string
+
+# PostgreSQL connection (defaults to postgres://localhost:5432/cookie-monsters)
+# DATABASE_URL=postgres://localhost:5432/cookie-monsters
+# DATABASE_NAME=cookie-monsters
+
+# Server port (default: 1337)
+# PORT=1337
+
+# OAuth — omit any block to disable that login strategy
+# FACEBOOK_CLIENT_ID=
+# FACEBOOK_CLIENT_SECRET=
+
+# GOOGLE_CONSUMER_KEY=
+# GOOGLE_CONSUMER_SECRET=
+
+# GITHUB_CLIENT_ID=
+# GITHUB_CLIENT_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ npm-debug.log
 
 # macOS metadata
 .DS_Store
+
+# Local environment variables (use .env.example as template)
+.env

--- a/README.md
+++ b/README.md
@@ -9,7 +9,37 @@ See me live at https://cookie-monsters.herokuapp.com/
 Cookie Monsters is the ultimate e-Commerce platform for lovers of cookies. Originally built as a senior phase project by Fullstack Academy's greatest trio of students, it has risen in prominence and now haunts public health professionals with nightmares of creeping obesity and diabetes. 
 
 ## Project Setup
-TODO
+
+**Prerequisites:** Node.js ≥ 18, PostgreSQL running locally.
+
+```sh
+# 1. Install dependencies
+npm ci
+
+# 2. Create a local .env file from the example
+cp .env.example .env
+
+# 3. Edit .env and set SESSION_SECRET to any long random string.
+#    Adjust DATABASE_URL if your Postgres instance isn't at localhost:5432.
+
+# 4. Create the database
+createdb cookie-monsters
+
+# 5. Start the dev server (runs on http://localhost:1337 by default)
+npm start
+```
+
+**Environment variables** (see [.env.example](.env.example) for the full list):
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `SESSION_SECRET` | **yes** | — | Secret key used to sign the session cookie |
+| `DATABASE_URL` | no | `postgres://localhost:5432/cookie-monsters` | PostgreSQL connection string |
+| `DATABASE_NAME` | no | `cookie-monsters` | Database name (overrides the name in `DATABASE_URL`) |
+| `PORT` | no | `1337` | HTTP port |
+| `FACEBOOK_CLIENT_ID` / `FACEBOOK_CLIENT_SECRET` | no | — | Enables Facebook OAuth login |
+| `GOOGLE_CONSUMER_KEY` / `GOOGLE_CONSUMER_SECRET` | no | — | Enables Google OAuth login |
+| `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | no | — | Enables GitHub OAuth login |
 
 ## Built with love using
 * Node.js


### PR DESCRIPTION
## Summary

- Replaces the empty `## Project Setup` README stub with a step-by-step first-run guide (prerequisites, `npm ci`, `.env` setup, `createdb`, `npm start`)
- Adds `.env.example` listing every env var the app reads, with inline comments indicating which are required vs optional and what they do
- Adds `.env` to `.gitignore` so local secrets aren't accidentally committed

Fixes #184.

## Test plan

- [ ] Fresh clone: copy `.env.example` → `.env`, set `SESSION_SECRET`, run `createdb cookie-monsters && npm ci && npm start` — server should bind on port 1337
- [ ] Verify `npm test` still passes (37 passing / 7 pending expected)
- [ ] Confirm `.env` is gitignored and `.env.example` is tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)