### PR TITLE
fix: repair broken OAuth login path

### DIFF
--- a/db/models/oauth.js
+++ b/db/models/oauth.js
@@ -4,6 +4,7 @@ const debug = require('debug')('oauth')
 const Sequelize = require('sequelize')
 const db = require('../../db')
 const Promise = require('bluebird')
+const User = require('./user')
 
 const OAuth = db.define(
   'oauths',
@@ -28,23 +29,23 @@ const OAuth = db.define(
 )
 
 OAuth.V2 = (accessToken, refreshToken, profile, done) =>
-  this.findOrCreate({
+  OAuth.findOrCreate({
     where: {
       provider: profile.provider,
       uid: profile.id,
     },
   })
-    .then(oauth => {
+    .then(([oauth]) => {
       debug(
         'provider:%s will log in user:{name=%s uid=%s}',
         profile.provider,
         profile.displayName,
-        token.uid
+        oauth.uid
       )
       oauth.profileJson = profile
       return Promise.props({
         oauth,
-        user: token.getUser(),
+        user: oauth.getUser(),
         _saveProfile: oauth.save(),
       })
     })

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = {
     return process.env.NODE_ENV === 'production'
   },
   get baseUrl() {
-    return env.BASE_URL || `http://localhost:${PORT}`
+    return env.BASE_URL || `http://localhost:${this.port}`
   },
   get port() {
     return env.PORT || 1337

--- a/server/auth.js
+++ b/server/auth.js
@@ -41,7 +41,7 @@ OAuth.setupStrategy({
   config: {
     clientID: env.FACEBOOK_CLIENT_ID,
     clientSecret: env.FACEBOOK_CLIENT_SECRET,
-    callbackURL: `${app.rootUrl}/api/auth/login/facebook`,
+    callbackURL: `${app.baseUrl}/api/auth/login/facebook`,
   },
   passport,
 })
@@ -54,7 +54,7 @@ OAuth.setupStrategy({
   config: {
     consumerKey: env.GOOGLE_CONSUMER_KEY,
     consumerSecret: env.GOOGLE_CONSUMER_SECRET,
-    callbackURL: `${app.rootUrl}/api/auth/login/google`,
+    callbackURL: `${app.baseUrl}/api/auth/login/google`,
   },
   passport,
 })
@@ -66,8 +66,8 @@ OAuth.setupStrategy({
   strategy: require('passport-github2').Strategy,
   config: {
     clientID: env.GITHUB_CLIENT_ID,
-    clientSecrets: env.GITHUB_CLIENT_SECRET,
-    callbackURL: `${app.rootUrl}/api/auth/login/github`,
+    clientSecret: env.GITHUB_CLIENT_SECRET,
+    callbackURL: `${app.baseUrl}/api/auth/login/github`,
   },
   passport,
 })


### PR DESCRIPTION
## Summary

- Replace `app.rootUrl` (undefined) with `app.baseUrl` in all three OAuth callback URLs — Facebook, Google, and GitHub were all producing `"undefined/api/auth/..."` strings
- Fix GitHub strategy config key from `clientSecrets` (typo) to `clientSecret`
- Fix `db/models/oauth.js` `OAuth.V2`: switch `this.findOrCreate` → `OAuth.findOrCreate` (arrow function; `this` was `undefined`/global), destructure the `[instance, created]` tuple returned by Sequelize's `findOrCreate`, replace stray `token.uid` / `token.getUser()` references with `oauth.uid` / `oauth.getUser()`, and add the missing `User` import

Fixes #180

## Test plan

- [ ] Set Facebook/Google/GitHub OAuth env vars and confirm callback URLs resolve correctly (no `undefined` prefix)
- [ ] Attempt GitHub OAuth login and verify the secret is passed (no "missing client secret" error)
- [ ] Complete an OAuth signup flow and confirm a `User` record is created without a `ReferenceError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)