### PR TITLE
chore: remove dead app/**/*.test.js glob from test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "packageManager": "pnpm@11.5.0",
   "scripts": {
-    "test": "mocha --require ./babel-register.js --require ./test-setup.js app/**/*.test.js app/**/*.test.jsx db/**/*.test.js server/**/*.test.js",
-    "test-watch": "mocha --require ./babel-register.js --require ./test-setup.js --watch app/**/*.test.js app/**/*.test.jsx db/**/*.test.js server/**/*.test.js",
+    "test": "mocha --require ./babel-register.js --require ./test-setup.js app/**/*.test.jsx db/**/*.test.js server/**/*.test.js",
+    "test-watch": "mocha --require ./babel-register.js --require ./test-setup.js --watch app/**/*.test.jsx db/**/*.test.js server/**/*.test.js",
     "build": "webpack",
     "build-watch": "webpack --watch",
     "start[dev]": "check-node-version --node >=18.0.0 && nodemon server/start.js",


### PR DESCRIPTION
## Summary

- Removes `app/**/*.test.js` from the `test` and `test-watch` scripts in `package.json`
- All component tests use `.test.jsx`; this pattern matched nothing and emitted a mocha warning on every run

Closes #192

## Test plan

- [x] `pnpm test` passes 37 tests with no `Cannot find any files matching pattern "app/**/*.test.js"` warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)