### PR TITLE
fix: redirect /cart to /viewcart

### DIFF
--- a/app/main.tsx
+++ b/app/main.tsx
@@ -25,6 +25,7 @@ createRoot(rootEl).render(
         <Route path="/" element={<AppContainer />}>
           <Route index element={<Navigate to="/products" replace />} />
           <Route path="products" element={<ProductsContainer />} />
+          <Route path="cart" element={<Navigate to="/viewcart" replace />} />
           <Route path="viewcart" element={<CartViewContainer />} />
           <Route path="order" element={<Order />} />
           <Route path="reviews" element={<Reviews />} />


### PR DESCRIPTION
## Summary

- Navigating to `/cart` previously returned a blank page because React Router had no matching route (`No routes matched location "/cart"`)
- Adds a single `<Route path="cart" element={<Navigate to="/viewcart" replace />} />` in `app/main.tsx`, making `/cart` a client-side alias for `/viewcart`
- The existing `/viewcart` canonical URL is unchanged; no breaking URL changes

## Test plan

- [ ] Navigate to `/cart` — should redirect to `/viewcart` and render the cart
- [ ] Navigate directly to `/viewcart` — should still work as before
- [ ] Verify no React Router `No routes matched` console error on `/cart`

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)