### PR TITLE
security: remove TEMP debug branch that exposes all orders to unauthenticated users

### DIFF
--- a/server/orders.js
+++ b/server/orders.js
@@ -51,22 +51,7 @@ module.exports = require('express')
         .then(orders => res.status(200).json(orders))
         .catch(next)
     } else {
-      // TEMP to test
-      return Order.findAll({
-        include: [
-          {
-            model: Product,
-            through: {
-              attributes: ['quantity', 'price'],
-            },
-          },
-        ],
-      })
-        .then(orders => _promisifyOrderProps(orders))
-        .then(orders => Promise.all(orders))
-        .then(orders => res.json(orders))
-        .catch(next)
-      // res.status(403).send("Cannot view without req.user");
+      res.status(403).send('Cannot view without req.user')
     }
   })
 


### PR DESCRIPTION
## Summary

- Removes the `// TEMP to test` else-branch in `GET /api/orders` that returned all orders to unauthenticated users
- Replaces it with the correct `res.status(403).send('Cannot view without req.user')` response
- Unauthenticated requests to `GET /api/orders/` now correctly receive a 403 Forbidden response instead of the full order list

## Security Impact

Before this fix, any unauthenticated request to `GET /api/orders/` received the complete list of all customer orders (including shipping addresses, user associations, and order details). This was a serious data exposure vulnerability.

## Test plan

- [ ] Verify that unauthenticated `GET /api/orders/` returns 403 Forbidden
- [ ] Verify that authenticated non-admin users can still retrieve their own orders
- [ ] Verify that authenticated admin users can still retrieve all orders
- [ ] Run full test suite: `npm test`

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)