### PR TITLE
ux: replace alert() calls with console.error and Redux state feedback

### DIFF
--- a/app/components/CartView.tsx
+++ b/app/components/CartView.tsx
@@ -10,13 +10,25 @@ interface CartViewProps {
   submitOrder: (cart: CartItem[]) => void
   removeFromCart: (productId: number) => void
   navigateToLogin: () => void
+  successMessage?: string | null
+  errorMessage?: string | null
 }
 
-export default function CartView({ cart, auth, submitOrder, removeFromCart, navigateToLogin }: CartViewProps) {
+export default function CartView({ cart, auth, submitOrder, removeFromCart, navigateToLogin, successMessage, errorMessage }: CartViewProps) {
   return (
     <div id="cart-view" className="container">
       <Hero />
       <br />
+      {successMessage && (
+        <div className="alert alert-success" role="alert">
+          {successMessage}
+        </div>
+      )}
+      {errorMessage && (
+        <div className="alert alert-danger" role="alert">
+          {errorMessage}
+        </div>
+      )}
       <div className="row">
         <div className="col-sm-6 col-xs-12">
           {cart.length < 1 ? (

--- a/app/containers/CartViewContainer.tsx
+++ b/app/containers/CartViewContainer.tsx
@@ -10,6 +10,8 @@ function mapStateToProps(state: RootState) {
   return {
     cart: state.cart,
     auth: state.auth,
+    successMessage: state.orders.successMessage,
+    errorMessage: state.orders.errorMessage,
   }
 }
 

--- a/app/reducers/orders.ts
+++ b/app/reducers/orders.ts
@@ -8,18 +8,22 @@ import type { NavigateFunction } from 'react-router-dom'
 interface OrdersState {
   orders: Order[]
   selectedOrder: Partial<Order>
+  successMessage: string | null
+  errorMessage: string | null
 }
 
 const ordersSlice = createSlice({
   name: 'orders',
-  initialState: { orders: [], selectedOrder: {} } as OrdersState,
+  initialState: { orders: [], selectedOrder: {}, successMessage: null, errorMessage: null } as OrdersState,
   reducers: {
     setOrders: (state, action: PayloadAction<Order[]>) => { state.orders = action.payload },
     selectOrder: (state, action: PayloadAction<Partial<Order>>) => { state.selectedOrder = action.payload },
+    setOrderSuccess: (state, action: PayloadAction<string | null>) => { state.successMessage = action.payload; state.errorMessage = null },
+    setOrderError: (state, action: PayloadAction<string | null>) => { state.errorMessage = action.payload; state.successMessage = null },
   },
 })
 
-export const { selectOrder } = ordersSlice.actions
+export const { selectOrder, setOrderSuccess, setOrderError } = ordersSlice.actions
 
 export const receiveOrders = () => (dispatch: AppDispatch) =>
   axios
@@ -37,11 +41,15 @@ export function submitOrder(cart: CartItem[], navigate?: NavigateFunction) {
     axios
       .post('/api/orders/', order)
       .then(() => {
-        alert('Cookies are on the way!')
+        dispatch(setOrderSuccess('Cookies are on the way!'))
         dispatch(emptyCart())
-        navigate && navigate('/myorders')
+        navigate && navigate('/myorders'))
       })
-      .catch(err => alert(err))
+      .catch(err => {
+        const message = err?.response?.data?.message || err?.message || 'Order submission failed. Please try again.'
+        console.error('Order submission error:', err)
+        dispatch(setOrderError(message))
+      })
 }
 
 export default ordersSlice.reducer

--- a/app/reducers/orders.ts
+++ b/app/reducers/orders.ts
@@ -43,7 +43,7 @@ export function submitOrder(cart: CartItem[], navigate?: NavigateFunction) {
       .then(() => {
         dispatch(setOrderSuccess('Cookies are on the way!'))
         dispatch(emptyCart())
-        navigate && navigate('/myorders'))
+        navigate && navigate('/myorders')
       })
       .catch(err => {
         const message = err?.response?.data?.message || err?.message || 'Order submission failed. Please try again.'


### PR DESCRIPTION
## Summary

- Replace blocking `alert()` calls in the order submission thunk with non-blocking feedback
- On success, dispatch `setOrderSuccess()` to store a human-readable message in Redux state
- On failure, extract a readable error message from the Axios error response, log it with `console.error()`, and dispatch `setOrderError()` for UI display
- Update `CartView` to render Bootstrap alert banners for success/error messages from Redux state
- Update `CartViewContainer` to wire `orders.successMessage` and `orders.errorMessage` from Redux state into `CartView`

Closes #202.

## Changes

- `app/reducers/orders.ts`: Added `successMessage`/`errorMessage` to `OrdersState`, added `setOrderSuccess`/`setOrderError` action reducers, replaced `alert()` calls with Redux dispatches and `console.error`
- `app/components/CartView.tsx`: Added optional `successMessage`/`errorMessage` props and Bootstrap alert divs to display feedback
- `app/containers/CartViewContainer.tsx`: Added `state.orders.successMessage` and `state.orders.errorMessage` to `mapStateToProps`

## Test plan

- [ ] Submit an order successfully and confirm the page shows "Cookies are on the way!" without a blocking browser dialog
- [ ] Submit an order while unauthenticated or with a server error and confirm a non-blocking error message is displayed
- [ ] Confirm `console.error` is called on failure with the full error object
- [ ] Run `npm test` — all existing tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)