### PR TITLE
fix: invoke forbidden() result so 403 is actually sent

### DIFF
--- a/server/auth.filters.js
+++ b/server/auth.filters.js
@@ -12,8 +12,7 @@ const selfOnly = action => (req, res, next) => {
   next()
 }
 
-const forbidden = message => (req, res, next) => {
-  console.log('running forbidden')
+const forbidden = (res, message) => {
   return res.status(403).send(message)
 }
 

--- a/server/orders.js
+++ b/server/orders.js
@@ -275,7 +275,7 @@ module.exports = require('express')
         .then(order => res.json(order))
         .catch(next)
     } else {
-      forbidden('You are not authorized to do this.')
+      return forbidden(res, 'You are not authorized to do this.')
     }
   })
 
@@ -288,7 +288,7 @@ module.exports = require('express')
         .then(order => res.status(200).json(order))
         .catch(next)
     } else {
-      forbidden('You are not authorized to do this.')
+      return forbidden(res, 'You are not authorized to do this.')
     }
   })
 
@@ -301,7 +301,7 @@ module.exports = require('express')
         .then(res.sendStatus(200))
         .catch(next)
     } else {
-      forbidden('You are not authorized to do this.')
+      return forbidden(res, 'You are not authorized to do this.')
     }
   })
 
@@ -337,7 +337,7 @@ module.exports = require('express')
         .then(res.sendStatus(200))
         .catch(next)
     } else {
-      forbidden('You are not authorized to do this.')
+      return forbidden(res, 'You are not authorized to do this.')
     }
   })
 
@@ -350,7 +350,7 @@ module.exports = require('express')
         .then(res.sendStatus(200))
         .catch(next)
     } else {
-      forbidden('You are not authorized to do this.')
+      return forbidden(res, 'You are not authorized to do this.')
     }
   })
 

--- a/server/users.js
+++ b/server/users.js
@@ -18,7 +18,7 @@ module.exports = require('express')
         .then(users => res.json(users))
         .catch(next)
     } else {
-      forbidden('only admins can list all users')
+      return forbidden(res, 'only admins can list all users')
     }
   })
 


### PR DESCRIPTION
## Summary

- `forbidden()` in `server/auth.filters.js` was a curried middleware factory that returned `(req, res, next) => { res.status(403).send(message) }`, but every call site discarded the returned function without invoking it
- The `res.status(403).send()` never ran, causing requests to hang instead of returning 403
- Simplified `forbidden()` to send directly: `const forbidden = (res, message) => res.status(403).send(message)`
- Updated all 6 call sites in `server/orders.js` (5 sites) and `server/users.js` (1 site) to pass `res` as first argument

Closes #211.

## Test plan

- [x] Run `npm test` — 37 passing, 7 pending, 0 failing
- [x] Verified only `server/auth.filters.js`, `server/orders.js`, and `server/users.js` are modified
- [x] Non-admin requests to admin-only order routes now correctly receive 403 instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)