### PR TITLE
fix: add callback to req.logout() for Passport 0.6+ compatibility

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -124,8 +124,18 @@ auth.post('/:strategy/login', (req, res, next) =>
 )
 
 auth.post('/logout', (req, res, next) => {
-  req.logout()
-  res.redirect('/api/auth/whoami')
+  const done = err => {
+    if (err) return next(err)
+    res.redirect('/api/auth/whoami')
+  }
+  // Passport 0.6+ made req.logout() asynchronous and requires a callback.
+  // Older versions are synchronous and ignore the callback argument.
+  if (req.logout.length > 0) {
+    req.logout(done)
+  } else {
+    req.logout()
+    done()
+  }
 })
 
 module.exports = auth


### PR DESCRIPTION
## Summary

- `req.logout()` was called without a callback in `server/auth.js`, which silently fails to end the session in Passport 0.6+ and may throw an unhandled error in some environments
- Added backward-compatible callback support using `req.logout.length` to detect Passport version at runtime: Passport 0.6+ sets `req.logout.length > 0`, older versions (synchronous) have `req.logout.length === 0`
- With older Passport (< 0.6), `req.logout()` is called synchronously then the redirect callback fires; with Passport 0.6+, the async callback form is used

Closes #198

## Test plan

- [x] Run `npm test` — all 37 tests pass, 7 pending, 0 failing
- [x] The `/api/auth POST /logout when logged in` test specifically verifies the logout redirects correctly and the session is destroyed
- [x] Login flow still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)