### PR TITLE
fix: add POST /api/auth/local/signup route for user registration

### DIFF
--- a/app/components/SignUp.tsx
+++ b/app/components/SignUp.tsx
@@ -4,7 +4,7 @@ import { signup } from '../reducers/auth'
 import type { AppDispatch } from '../store'
 
 interface SignupProps {
-  signup: (username: string, password: string) => void
+  signup: (name: string, email: string, password: string) => void
 }
 
 export const Signup = ({ signup }: SignupProps) => (
@@ -14,15 +14,22 @@ export const Signup = ({ signup }: SignupProps) => (
       onSubmit={evt => {
         evt.preventDefault()
         const form = evt.currentTarget
-        const username = (form.elements.namedItem('username') as HTMLInputElement).value
+        const name = (form.elements.namedItem('name') as HTMLInputElement).value
+        const email = (form.elements.namedItem('email') as HTMLInputElement).value
         const password = (form.elements.namedItem('password') as HTMLInputElement).value
-        signup(username, password)
+        signup(name, email, password)
       }}
     >
       <input
         className="form-control auth-field"
-        name="username"
-        placeholder="Username"
+        name="name"
+        placeholder="Full Name"
+      />
+      <input
+        className="form-control auth-field"
+        name="email"
+        type="email"
+        placeholder="Email"
       />
       <input
         className="form-control auth-field"
@@ -37,8 +44,8 @@ export const Signup = ({ signup }: SignupProps) => (
 
 function mapDispatchToProps(dispatch: AppDispatch) {
   return {
-    signup: (username: string, password: string) =>
-      dispatch(signup(username, password)),
+    signup: (name: string, email: string, password: string) =>
+      dispatch(signup(name, email, password)),
   }
 }
 

--- a/app/reducers/auth.ts
+++ b/app/reducers/auth.ts
@@ -27,9 +27,9 @@ export const login = (username: string, password: string) => (dispatch: AppDispa
     .then(() => dispatch(whoami()))
     .catch(() => dispatch(whoami()))
 
-export const signup = (username: string, password: string) => (dispatch: AppDispatch) =>
+export const signup = (name: string, email: string, password: string) => (dispatch: AppDispatch) =>
   axios
-    .post('/api/auth/local/signup', { username, password })
+    .post('/api/auth/local/signup', { name, email, password })
     .then(() => dispatch(whoami()))
     .catch(() => dispatch(whoami()))
 

--- a/server/auth.js
+++ b/server/auth.js
@@ -117,6 +117,21 @@ passport.use(
 
 auth.get('/whoami', (req, res) => res.send(req.user))
 
+auth.post('/local/signup', (req, res, next) => {
+  if (req.user) {
+    return res.status(403).send('Already logged in')
+  }
+  const { name, email, password } = req.body
+  User.create({ name, email, password })
+    .then(user => {
+      req.login(user, err => {
+        if (err) return next(err)
+        res.status(201).json(user)
+      })
+    })
+    .catch(next)
+})
+
 auth.post('/:strategy/login', (req, res, next) =>
   passport.authenticate(req.params.strategy, {
     successRedirect: '/',


### PR DESCRIPTION
## Summary

- Add `POST /api/auth/local/signup` route to `server/auth.js` that creates a new user via `User.create()` and logs them in via `req.login()`
- Update the `signup` thunk in `app/reducers/auth.ts` to accept `name`, `email`, and `password` (matching what `User.create()` requires) instead of the incorrect `username` and `password` fields
- Update `app/components/SignUp.tsx` to collect `name`, `email`, and `password` from the user, replacing the broken `username` field

## Root cause

The signup form only collected `username` and `password`, but `User.create()` requires `name`, `email`, and `password`. The thunk POSTed to `/api/auth/local/signup` which had no matching server route, causing a 404 that was silently swallowed by the `.catch(() => dispatch(whoami()))` fallback.

## Test plan

- [ ] Start the app and navigate to the Sign Up page
- [ ] Fill in Full Name, Email, and Password
- [ ] Click Sign Up — should log you in and redirect to home
- [ ] Try signing up while already logged in — should return 403
- [ ] All existing tests should continue to pass

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)