### PR TITLE
fix: wrap res.sendStatus(200) in arrow function in .then() chains

### DIFF
--- a/server/orders.js
+++ b/server/orders.js
@@ -111,7 +111,7 @@ module.exports = require('express')
               )
             }
           })
-          .then(res.sendStatus(200))
+          .then(() => res.sendStatus(200))
           .catch(next)
       }
       // ... and the user does not specify a userID
@@ -223,7 +223,7 @@ module.exports = require('express')
             )
           }
         })
-        .then(res.sendStatus(200))
+        .then(() => res.sendStatus(200))
         .catch(next)
     }
   })
@@ -298,7 +298,7 @@ module.exports = require('express')
     if (req.user.isAdmin) {
       return Order.findByPk(req.params.id)
         .then(order => order.destroy())
-        .then(res.sendStatus(200))
+        .then(() => res.sendStatus(200))
         .catch(next)
     } else {
       forbidden('You are not authorized to do this.')
@@ -334,7 +334,7 @@ module.exports = require('express')
             })
           )
         })
-        .then(res.sendStatus(200))
+        .then(() => res.sendStatus(200))
         .catch(next)
     } else {
       forbidden('You are not authorized to do this.')
@@ -347,7 +347,7 @@ module.exports = require('express')
     if (req.user.isAdmin) {
       return Order.findByPk(req.params.orderId)
         .then(order => order.removeProduct(req.params.productId))
-        .then(res.sendStatus(200))
+        .then(() => res.sendStatus(200))
         .catch(next)
     } else {
       forbidden('You are not authorized to do this.')


### PR DESCRIPTION
## Summary

- `.then(res.sendStatus(200))` eagerly calls `sendStatus` when the promise chain is constructed, not when the promise resolves. The return value of `sendStatus` (which is `res`) is then used as the fulfillment handler.
- This fix wraps all five occurrences in `server/orders.js` with `() =>` arrow functions so `sendStatus` executes at the correct time (after the preceding promise resolves).
- The five routes affected are: admin POST with userId param (line 114), guest POST (line 226), DELETE /:id (line 301), POST /:id/products (line 337), and DELETE /:orderId/products/:productId (line 350).

Closes #212

## Test plan

- [x] Run `npm test` — 37 passing, 7 pending, 0 failing
- [x] Verify no remaining `.then(res.sendStatus(200))` patterns in `server/orders.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)