### PR TITLE
Add ownership check on GET /api/users/:id

### DIFF
--- a/server/users.js
+++ b/server/users.js
@@ -58,9 +58,14 @@ module.exports = require('express')
   })
 
   // Action: Get user by ID
-  // Roles: User, Admin
-  // Notes:
-  .get('/:id', (req, res, next) => res.status(200).json(req.foundUser));
+  // Roles: User (own profile only), Admin
+  // Notes: Users may only read their own profile; admins may read any profile.
+  .get('/:id', (req, res, next) => {
+    if (!req.user.isAdmin && String(req.user.id) !== String(req.params.id)) {
+      return forbidden(res, 'You may only view your own profile');
+    }
+    return res.status(200).json(req.foundUser);
+  });
 
 // Action: Modify user by ID
 // Roles: User, Admin


### PR DESCRIPTION
## Summary
Add authorization so users can only read their own profile. In the users router GET /:id handler, compare req.user.id to req.params.id and return 403 if they differ. Admins are permitted to read any profile.

Closes #233