### PR TITLE
Remove password_digest from User API responses

### DIFF
--- a/db/models/user.js
+++ b/db/models/user.js
@@ -55,6 +55,12 @@ const User = db.define(
   }
 );
 
+User.prototype.toJSON = function () {
+  const values = Object.assign({}, this.dataValues)
+  delete values.password_digest
+  return values
+}
+
 User.prototype.authenticate = function (plaintext) {
   return new Promise((resolve, reject) =>
     bcrypt.compare(plaintext, this.password_digest, (err, result) =>

--- a/db/models/user.js
+++ b/db/models/user.js
@@ -56,10 +56,10 @@ const User = db.define(
 );
 
 User.prototype.toJSON = function () {
-  const values = Object.assign({}, this.dataValues)
-  delete values.password_digest
-  return values
-}
+  const values = Object.assign({}, this.dataValues);
+  delete values.password_digest;
+  return values;
+};
 
 User.prototype.authenticate = function (plaintext) {
   return new Promise((resolve, reject) =>


### PR DESCRIPTION
## Summary
Add a toJSON instance method on the User Sequelize model that deletes password_digest from dataValues before returning, ensuring password hashes are never leaked in API responses.

Closes #234