### PR TITLE
Fix guest order addProduct missing through wrapper

### DIFF
--- a/server/orders.js
+++ b/server/orders.js
@@ -200,15 +200,31 @@ module.exports = require('express')
         })
         .then(products => {
           if (products) {
-            products.forEach(product =>
-              order.addProduct(product, {
-                quantity: orderLineItems[product.id].quantity,
-                price: product.price,
-              })
+            return Promise.all(
+              products.map(product =>
+                order.addProduct(product, {
+                  through: {
+                    quantity: orderLineItems[product.id].quantity,
+                    price: product.price,
+                  },
+                })
+              )
             )
           }
         })
-        .then(() => res.sendStatus(200))
+        .then(() =>
+          Order.findByPk(order.id, {
+            include: [
+              {
+                model: Product,
+                through: {
+                  attributes: ['quantity', 'price'],
+                },
+              },
+            ],
+          })
+        )
+        .then(order => res.status(200).json(order))
         .catch(next)
     }
   })

--- a/server/orders.test.js
+++ b/server/orders.test.js
@@ -93,7 +93,62 @@ describe('/api/orders/', () => {
     })
   })
 
-  xdescribe('POST / (as Guest)', () => {})
+  describe('POST / (as Guest)', () => {
+    let product, orderId
+    before('Create product', () =>
+      db.didSync.then(() =>
+        Product.create({
+          name: 'Sugar Cookie',
+          description: 'Simple and sweet',
+          price: 2.0,
+          quantity: 50,
+          categories: [],
+        })
+      ).then(_product => {
+        product = _product
+      })
+    )
+    it('returns 200 with JSON order body (not a bare status)', () =>
+      request(app)
+        .post('/api/orders/')
+        .send({
+          shippingCarrier: 'FedEx',
+          orderLineItems: {
+            [product.id]: { quantity: 3 },
+          },
+        })
+        .expect(200)
+        .then(res => {
+          orderId = res.body.id
+          expect(res.body).to.be.an('object')
+          expect(res.body).to.have.property('id')
+          expect(res.body.shippingCarrier).to.equal('FedEx')
+        }))
+    it('persists quantity and price on the join table (through: {} fix)', () =>
+      request(app)
+        .post('/api/orders/')
+        .send({
+          shippingCarrier: 'FedEx',
+          orderLineItems: {
+            [product.id]: { quantity: 5 },
+          },
+        })
+        .expect(200)
+        .then(res => {
+          expect(res.body.products).to.be.an('array').with.lengthOf(1)
+          const lineItem = res.body.products[0].orderLineItems
+          expect(lineItem).to.have.property('quantity', 5)
+          expect(Number(lineItem.price)).to.equal(Number(product.price))
+        }))
+    after('destroy product and any created orders', () =>
+      Promise.all([
+        product.destroy(),
+        orderId
+          ? Order.findByPk(orderId).then(o => o && o.destroy())
+          : Promise.resolve(),
+      ])
+    )
+  })
   describe('POST / (as Non-Admin)', () => {
     const agent = request.agent(app)
     let user, product, id


### PR DESCRIPTION
## Summary
In the guest orders route, wrap the addProduct options with the correct Sequelize through:{} object so orderLineItem quantity and price are persisted to the join table. Also return the created order as JSON instead of a bare 200 status, consistent with authenticated order creation paths.

Closes #235