### PR TITLE
fix: store billingZip and shippingZip as STRING to preserve leading zeros

### DIFF
--- a/db/models/user.js
+++ b/db/models/user.js
@@ -24,12 +24,18 @@ const User = db.define(
     billingAddress: Sequelize.STRING,
     billingCity: Sequelize.STRING,
     billingState: Sequelize.STRING,
-    billingZip: Sequelize.INTEGER,
+    billingZip: {
+      type: Sequelize.STRING,
+      validate: { is: /^\d{5}(-\d{4})?$/ },
+    },
 
     shippingAddress: Sequelize.STRING,
     shippingCity: Sequelize.STRING,
     shippingState: Sequelize.STRING,
-    shippingZip: Sequelize.INTEGER,
+    shippingZip: {
+      type: Sequelize.STRING,
+      validate: { is: /^\d{5}(-\d{4})?$/ },
+    },
 
     // We support oauth, so users may or may not have passwords.
     password_digest: Sequelize.STRING,

--- a/db/models/user.test.js
+++ b/db/models/user.test.js
@@ -7,6 +7,24 @@ const { expect } = require('chai');
 describe('User', () => {
   before('wait for the db', () => db.didSync);
 
+  describe('billingZip / shippingZip', () => {
+    it('preserves a leading-zero zip code', () =>
+      User.create({ name: 'dude', password: 'ok', billingZip: '01234', shippingZip: '01234' })
+        .then(user => {
+          expect(user.billingZip).to.equal('01234');
+          expect(user.shippingZip).to.equal('01234');
+        }));
+
+    it('accepts ZIP+4 format', () =>
+      User.create({ name: 'dude', password: 'ok', billingZip: '01234-5678' })
+        .then(user => expect(user.billingZip).to.equal('01234-5678')));
+
+    it('rejects a non-zip string', () =>
+      User.create({ name: 'dude', password: 'ok', billingZip: 'ABCDE' })
+        .then(() => { throw new Error('should have rejected'); })
+        .catch(err => expect(err.name).to.equal('SequelizeValidationError')));
+  });
+
   describe('authenticate(plaintext: String) ~> Boolean', () => {
     it('resolves true if the password matches', () =>
       User.create({ name: 'dude', password: 'ok' })


### PR DESCRIPTION
## Summary

- Change `billingZip` and `shippingZip` from `Sequelize.INTEGER` to `Sequelize.STRING`
- Add `validate: { is: /^\d{5}(-\d{4})?$/ }` to both fields to enforce US zip code format (5-digit or ZIP+4)

`INTEGER` silently drops leading zeros, so `01234` (a Massachusetts zip) becomes `1234`. `STRING` preserves the full value.

Closes #204

## Test plan

- [ ] Run `npm test` — existing suite passes
- [ ] Verify a user record with zip `01234` round-trips correctly through the model

🤖 Generated with [Claude Code](https://claude.com/claude-code)