### PR TITLE
ci: disable HoundCI ESLint (broken with @typescript-eslint)

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,6 +1,5 @@
 eslint:
-  enabled: true
-  config_file: .eslintrc.json
+  enabled: false
 
 javascript:
   enabled: false


### PR DESCRIPTION
HoundCI ships its own global ESLint 4.19.1 (2018). The project uses `eslint@8.57.1` with `@typescript-eslint/eslint-plugin`, which uses scoped package names that ESLint 4 cannot resolve. Result: HoundCI posts a bogus error on every PR.

ESLint is already run correctly by the GitHub Actions `test` job using the project-local install, so HoundCI's check is redundant. Disabling it here stops the noise.