### PR TITLE
fix: upgrade passport to 0.7.0 (CVE-2022-25896 session fixation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "check-node-version": "^4.2.1",
     "cookie-session": "^2.0.0-alpha.1",
     "express": "^4.14.0",
-    "passport": "^0.3.2",
+    "passport": "^0.7.0",
     "passport-facebook": "^3.0.0",
     "passport-github2": "^0.1.10",
     "passport-google-oauth20": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^4.14.0
         version: 4.22.2
       passport:
-        specifier: ^0.3.2
-        version: 0.3.2
+        specifier: ^0.7.0
+        version: 0.7.0
       passport-facebook:
         specifier: ^3.0.0
         version: 3.0.0
@@ -2629,8 +2629,8 @@ packages:
     resolution: {integrity: sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==}
     engines: {node: '>= 0.4.0'}
 
-  passport@0.3.2:
-    resolution: {integrity: sha512-aqgxMQxuRz79M4LVo8fl3/bsh6Ozcb34G8MVDs7Oavy88ROLSVvTgYoWnX3TpxdQg66HiXvpb+lcuFPnDrmiOA==}
+  passport@0.7.0:
+    resolution: {integrity: sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==}
     engines: {node: '>= 0.4.0'}
 
   path-exists@3.0.0:
@@ -6435,10 +6435,11 @@ snapshots:
 
   passport-strategy@1.0.0: {}
 
-  passport@0.3.2:
+  passport@0.7.0:
     dependencies:
       passport-strategy: 1.0.0
       pause: 0.0.1
+      utils-merge: 1.0.1
 
   path-exists@3.0.0: {}
 

--- a/server/auth.js
+++ b/server/auth.js
@@ -139,18 +139,10 @@ auth.post('/:strategy/login', (req, res, next) =>
 );
 
 auth.post('/logout', (req, res, next) => {
-  const done = err => {
+  req.logout(err => {
     if (err) return next(err);
     res.redirect('/api/auth/whoami');
-  };
-  // Passport 0.6+ made req.logout() asynchronous and requires a callback.
-  // Older versions are synchronous and ignore the callback argument.
-  if (req.logout.length > 0) {
-    req.logout(done);
-  } else {
-    req.logout();
-    done();
-  }
+  });
 });
 
 module.exports = auth;

--- a/server/start.js
+++ b/server/start.js
@@ -33,6 +33,19 @@ module.exports = app
   .use(bodyParser.urlencoded({ extended: true }))
   .use(bodyParser.json())
 
+  // Passport 0.6+ calls req.session.regenerate() and req.session.save() on login
+  // to prevent session fixation. cookie-session does not implement these methods,
+  // so we add no-op stubs to keep passport happy.
+  .use((req, _res, next) => {
+    if (req.session && !req.session.regenerate) {
+      req.session.regenerate = cb => cb();
+    }
+    if (req.session && !req.session.save) {
+      req.session.save = cb => cb();
+    }
+    next();
+  })
+
   // Authentication middleware
   .use(passport.initialize())
   .use(passport.session())


### PR DESCRIPTION
## Summary

- Upgrades `passport` from `0.3.2` → `0.7.0`, resolving CVE-2022-25896 (session fixation)
- Passport 0.6+ calls `req.session.regenerate()` on login to rotate the session ID; this project uses `cookie-session` which lacks that method, so two no-op stubs (`regenerate`, `save`) are added in `server/start.js` immediately before the passport middleware
- Simplifies the `req.logout()` call in `server/auth.js` to always use the async form (the version-detection shim is no longer needed)

## Test plan

- [x] `pnpm install` resolves `passport@0.7.0` (confirmed in lock file)
- [x] Server starts cleanly (`SESSION_SECRET` set, DB running)
- [x] Signup creates a user and sets a signed session cookie containing `{"passport":{"user":<id>}}`
- [x] `GET /api/auth/whoami` with that cookie returns the full user object
- [x] `POST /api/auth/local/login` returns 302 + new session cookie; whoami confirms session
- [x] `POST /api/auth/logout` returns 302; subsequent whoami returns empty (session cleared)
- [x] `pnpm test` — 48 passing, 0 failing

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)