### PR TITLE
chore: replace body-parser with express built-ins

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@reduxjs/toolkit": "^2.8.2",
     "axios": "^1.16.1",
     "bcrypt": "^5.1.1",
-    "body-parser": "^1.15.2",
     "chalk": "^1.1.3",
     "cookie-session": "^2.0.0-alpha.1",
     "express": "^4.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       bcrypt:
         specifier: ^5.1.1
         version: 5.1.1
-      body-parser:
-        specifier: ^1.15.2
-        version: 1.20.5
       chalk:
         specifier: ^1.1.3
         version: 1.1.3

--- a/server/start.js
+++ b/server/start.js
@@ -1,5 +1,4 @@
 import express from 'express';
-import bodyParser from 'body-parser';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
 import passport from 'passport';
@@ -29,8 +28,8 @@ app
       ],
     })
   )
-  .use(bodyParser.urlencoded({ extended: true }))
-  .use(bodyParser.json())
+  .use(express.urlencoded({ extended: true }))
+  .use(express.json())
   // Passport 0.6+ calls req.session.regenerate/save; cookie-session lacks these,
   // so we add no-op stubs.
   .use((req, _res, next) => {


### PR DESCRIPTION
## Summary

- Remove `body-parser` from `dependencies`
- Replace `bodyParser.urlencoded()` and `bodyParser.json()` in `server/start.js` with `express.urlencoded()` and `express.json()`

Express 4.16+ ships both parsers natively. `body-parser` is now just a thin re-export of the same underlying code, so this is a zero-behavior-change cleanup.

## Test plan

- [x] `GET /` → 200 HTML
- [x] `GET /api/products` → 12 products
- [x] `POST /api/auth/local/signup` with JSON body → 201 (exercises `express.json()`)
- [x] `POST /api/auth/local/login` with urlencoded body → 302 (exercises `express.urlencoded()`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)