### PR TITLE
chore: replace chalk with Node built-in util.styleText

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -1,6 +1,5 @@
 import { exec } from 'child_process';
-import { promisify } from 'util';
-import chalk from 'chalk';
+import { promisify, styleText } from 'util';
 import db, { dbName, dbUrl } from './sequelize.js';
 import app from '../index.js';
 
@@ -14,11 +13,11 @@ async function sync(force = app.isTesting, retries = 0, maxRetries = 5) {
     console.log(`Synced models to db ${dbUrl}`);
   } catch (fail) {
     if (app.isProduction || retries > maxRetries) {
-      console.error(chalk.red(`********** database error ***********`));
-      console.error(chalk.red(`    Couldn't connect to ${dbUrl}`));
+      console.error(styleText('red',`********** database error ***********`));
+      console.error(styleText('red',`    Couldn't connect to ${dbUrl}`));
       console.error();
-      console.error(chalk.red(fail));
-      console.error(chalk.red(`*************************************`));
+      console.error(styleText('red',fail));
+      console.error(styleText('red',`*************************************`));
       return;
     }
     console.log(

--- a/db/sequelize.js
+++ b/db/sequelize.js
@@ -1,5 +1,5 @@
+import { styleText } from 'util';
 import createDebug from 'debug';
-import chalk from 'chalk';
 import Sequelize from 'sequelize';
 import app from '../index.js';
 
@@ -10,7 +10,7 @@ export const dbName =
 export const dbUrl =
   process.env.DATABASE_URL || `postgres://localhost:5432/${dbName}`;
 
-console.log(chalk.yellow(`Opening database connection to ${dbUrl}`));
+console.log(styleText('yellow', `Opening database connection to ${dbUrl}`));
 
 const db = new Sequelize(dbUrl, {
   logging: debug,

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@reduxjs/toolkit": "^2.8.2",
     "axios": "^1.16.1",
     "bcrypt": "^5.1.1",
-    "chalk": "^1.1.3",
     "cookie-session": "^2.0.0-alpha.1",
     "express": "^4.14.0",
     "passport": "^0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       bcrypt:
         specifier: ^5.1.1
         version: 5.1.1
-      chalk:
-        specifier: ^1.1.3
-        version: 1.1.3
       cookie-session:
         specifier: ^2.0.0-alpha.1
         version: 2.1.1
@@ -1150,17 +1147,9 @@ packages:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
 
-  ansi-regex@2.1.1:
-    resolution: {integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==}
-    engines: {node: '>=0.10.0'}
-
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
-
-  ansi-styles@2.2.1:
-    resolution: {integrity: sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==}
-    engines: {node: '>=0.10.0'}
 
   ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
@@ -1360,10 +1349,6 @@ packages:
   chai@4.5.0:
     resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
     engines: {node: '>=4'}
-
-  chalk@1.1.3:
-    resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==}
-    engines: {node: '>=0.10.0'}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -1973,10 +1958,6 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
-
-  has-ansi@2.0.0:
-    resolution: {integrity: sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==}
-    engines: {node: '>=0.10.0'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -3102,10 +3083,6 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
-  strip-ansi@3.0.1:
-    resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==}
-    engines: {node: '>=0.10.0'}
-
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -3121,10 +3098,6 @@ packages:
   supertest@7.2.2:
     resolution: {integrity: sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==}
     engines: {node: '>=14.18.0'}
-
-  supports-color@2.0.0:
-    resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}
-    engines: {node: '>=0.8.0'}
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -4732,11 +4705,7 @@ snapshots:
 
   ansi-colors@4.1.3: {}
 
-  ansi-regex@2.1.1: {}
-
   ansi-regex@5.0.1: {}
-
-  ansi-styles@2.2.1: {}
 
   ansi-styles@3.2.1:
     dependencies:
@@ -4982,14 +4951,6 @@ snapshots:
       loupe: 2.3.7
       pathval: 1.1.1
       type-detect: 4.1.0
-
-  chalk@1.1.3:
-    dependencies:
-      ansi-styles: 2.2.1
-      escape-string-regexp: 1.0.5
-      has-ansi: 2.0.0
-      strip-ansi: 3.0.1
-      supports-color: 2.0.0
 
   chalk@2.4.2:
     dependencies:
@@ -5748,10 +5709,6 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
-
-  has-ansi@2.0.0:
-    dependencies:
-      ansi-regex: 2.1.1
 
   has-bigints@1.1.0: {}
 
@@ -6911,10 +6868,6 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  strip-ansi@3.0.1:
-    dependencies:
-      ansi-regex: 2.1.1
-
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -6942,8 +6895,6 @@ snapshots:
       superagent: 10.3.0
     transitivePeerDependencies:
       - supports-color
-
-  supports-color@2.0.0: {}
 
   supports-color@5.5.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Remove `chalk@1.1.3` (released 2016) from `dependencies`
- Replace the three `chalk.red(...)` calls in `db/index.js` and the single `chalk.yellow(...)` call in `db/sequelize.js` with `util.styleText('red', ...)` / `util.styleText('yellow', ...)`

`util.styleText` shipped as stable in Node 22.0.0, which is already the minimum required by `engines.node`. No third-party package needed.

## Test plan

- [x] Server starts — yellow "Opening database connection" line renders via `styleText`
- [x] `GET /` → 200 HTML
- [x] `GET /api/products` → 12 products
- [x] `POST /api/auth/local/signup` → 201
- [x] `POST /api/auth/local/login` → 302

🤖 Generated with [Claude Code](https://claude.ai/claude-code)