### PR TITLE
fix: dynamic import volleyball so server loads without devDependencies

### DIFF
--- a/server/start.js
+++ b/server/start.js
@@ -3,7 +3,6 @@ import { resolve } from 'path';
 import { fileURLToPath } from 'url';
 import passport from 'passport';
 import cookieSession from 'cookie-session';
-import volleyball from 'volleyball';
 import pkg from '../index.js';
 import api from './api.js';
 
@@ -12,6 +11,7 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const app = express();
 
 if (!pkg.isProduction && !pkg.isTesting) {
+  const { default: volleyball } = await import('volleyball');
   app.use(volleyball);
 }
 


### PR DESCRIPTION
## Summary

`volleyball` is correctly in `devDependencies`, but `server/start.js` had a static top-level `import volleyball from 'volleyball'` that would throw `ERR_MODULE_NOT_FOUND` on startup in any `--prod` install (where devDeps are skipped) — even though the middleware is guarded behind `!isProduction`.

Change the static import to `await import('volleyball')` inside the `!isProduction` condition, so production builds never touch the package at all.

## Test plan

- [x] Server starts in dev mode — dynamic import succeeds, volleyball middleware active
- [x] `GET /` → 200 HTML
- [x] `GET /api/products` → 12 products
- [x] `POST /api/auth/local/signup` → 201
- [x] `POST /api/auth/local/login` → 302

🤖 Generated with [Claude Code](https://claude.ai/claude-code)