### PR TITLE
fix: move debug to dependencies and upgrade to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-router-dom": "^6.30.3",
     "redux": "^5.0.1",
     "redux-logger": "^3.0.6",
+    "debug": "^4.0.0",
     "sequelize": "^6.37.8"
   },
   "devDependencies": {
@@ -83,7 +84,6 @@
     "babel-loader": "^10.1.1",
     "chai": "^4.5.0",
     "cheerio": "1.0.0-rc.12",
-    "debug": "^2.6.0",
     "jsdom": "^29.1.1",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^8.10.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,13 +22,16 @@ importers:
         version: 2.12.0(react-redux@9.3.0(@types/react@19.2.15)(react@19.2.7)(redux@5.0.1))(react@19.2.7)
       axios:
         specifier: ^1.16.1
-        version: 1.16.1(debug@2.6.9)
+        version: 1.16.1(debug@4.4.3)
       bcrypt:
         specifier: ^5.1.1
         version: 5.1.1
       cookie-session:
         specifier: ^2.0.0-alpha.1
         version: 2.1.1
+      debug:
+        specifier: ^4.0.0
+        version: 4.4.3(supports-color@5.5.0)
       express:
         specifier: ^4.14.0
         version: 4.22.2
@@ -123,9 +126,6 @@ importers:
       cheerio:
         specifier: 1.0.0-rc.12
         version: 1.0.0-rc.12
-      debug:
-        specifier: ^2.6.0
-        version: 2.6.9
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -4806,9 +4806,9 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.16.1(debug@2.6.9):
+  axios@1.16.1(debug@4.4.3):
     dependencies:
-      follow-redirects: 1.16.0(debug@2.6.9)
+      follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.5
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
@@ -5576,9 +5576,9 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.16.0(debug@2.6.9):
+  follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
-      debug: 2.6.9
+      debug: 4.4.3
 
   for-each@0.3.5:
     dependencies:


### PR DESCRIPTION
## Summary

`debug` was listed in `devDependencies` at the ancient v2.6.0 (2017), but it is imported at the top level of production server files:

- `server/auth.js`
- `server/orders.js`
- `db/models/oauth.js`
- `db/sequelize.js`

A `pnpm install --prod` (no devDeps) would cause a `ERR_MODULE_NOT_FOUND` crash at startup. This moves it to `dependencies` and upgrades to the current v4 line. The `createDebug('namespace')` API is identical between v2 and v4.

## Test plan

- [x] Server starts — debug instrumentation active via v4
- [x] `GET /` → 200 HTML
- [x] `GET /api/products` → 12 products
- [x] `POST /api/auth/local/signup` → 201
- [x] `POST /api/auth/local/login` → 302

🤖 Generated with [Claude Code](https://claude.ai/claude-code)