### PR TITLE
chore: move redux-logger to devDependencies, guard with NODE_ENV

### DIFF
--- a/app/store.ts
+++ b/app/store.ts
@@ -3,10 +3,14 @@ import rootReducer from './reducers';
 import { createLogger } from 'redux-logger';
 import { whoami } from './reducers/auth';
 
+const isDev = process.env.NODE_ENV !== 'production';
+
 const store = configureStore({
   reducer: rootReducer,
   middleware: getDefaultMiddleware =>
-    getDefaultMiddleware().concat(createLogger()),
+    isDev
+      ? getDefaultMiddleware().concat(createLogger())
+      : getDefaultMiddleware(),
 });
 
 store.dispatch(whoami());

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "react-redux": "^9.3.0",
     "react-router-dom": "^6.30.3",
     "redux": "^5.0.1",
-    "redux-logger": "^3.0.6",
     "debug": "^4.0.0",
     "sequelize": "^6.37.8"
   },
@@ -78,6 +77,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/react-redux": "^7.1.34",
     "@types/redux-logger": "^3.0.13",
+    "redux-logger": "^3.0.6",
     "@typescript-eslint/eslint-plugin": "^8.61.0",
     "@typescript-eslint/parser": "^8.61.0",
     "ajv": "^8.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,9 +68,6 @@ importers:
       redux:
         specifier: ^5.0.1
         version: 5.0.1
-      redux-logger:
-        specifier: ^3.0.6
-        version: 3.0.6
       sequelize:
         specifier: ^6.37.8
         version: 6.37.8(pg@8.21.0)
@@ -147,6 +144,9 @@ importers:
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
+      redux-logger:
+        specifier: ^3.0.6
+        version: 3.0.6
       sinon:
         specifier: ^22.0.0
         version: 22.0.0


### PR DESCRIPTION
## Summary

`redux-logger` logs every Redux action dispatch to the browser console — it's a development debugging tool that shouldn't ship in production bundles and has no server-side usage.

- Move `redux-logger` from `dependencies` to `devDependencies` (`@types/redux-logger` was already there)
- Guard the middleware with `process.env.NODE_ENV !== 'production'` in `app/store.ts` so webpack's dead-code elimination removes it entirely from production builds

## Test plan

- [x] `pnpm build` — webpack compiles `app/store.ts` successfully with the conditional
- [x] `GET /` → 200, rebuilt `bundle.js` served
- [x] `GET /api/products` → 12 products
- [x] `POST /api/auth/local/signup` → 201
- [x] `POST /api/auth/local/login` → 302

🤖 Generated with [Claude Code](https://claude.ai/claude-code)