### PR TITLE
dep: upgrade prettier from v2 to v3

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -13,11 +13,11 @@ async function sync(force = app.isTesting, retries = 0, maxRetries = 5) {
     console.log(`Synced models to db ${dbUrl}`);
   } catch (fail) {
     if (app.isProduction || retries > maxRetries) {
-      console.error(styleText('red',`********** database error ***********`));
-      console.error(styleText('red',`    Couldn't connect to ${dbUrl}`));
+      console.error(styleText('red', `********** database error ***********`));
+      console.error(styleText('red', `    Couldn't connect to ${dbUrl}`));
       console.error();
-      console.error(styleText('red',fail));
-      console.error(styleText('red',`*************************************`));
+      console.error(styleText('red', fail));
+      console.error(styleText('red', `*************************************`));
       return;
     }
     console.log(

--- a/db/models/user.test.js
+++ b/db/models/user.test.js
@@ -7,19 +7,28 @@ describe('User', () => {
 
   describe('billingZip / shippingZip', () => {
     it('preserves a leading-zero zip code', () =>
-      User.create({ name: 'dude', password: 'ok', billingZip: '01234', shippingZip: '01234' })
-        .then(user => {
-          expect(user.billingZip).to.equal('01234');
-          expect(user.shippingZip).to.equal('01234');
-        }));
+      User.create({
+        name: 'dude',
+        password: 'ok',
+        billingZip: '01234',
+        shippingZip: '01234',
+      }).then(user => {
+        expect(user.billingZip).to.equal('01234');
+        expect(user.shippingZip).to.equal('01234');
+      }));
 
     it('accepts ZIP+4 format', () =>
-      User.create({ name: 'dude', password: 'ok', billingZip: '01234-5678' })
-        .then(user => expect(user.billingZip).to.equal('01234-5678')));
+      User.create({
+        name: 'dude',
+        password: 'ok',
+        billingZip: '01234-5678',
+      }).then(user => expect(user.billingZip).to.equal('01234-5678')));
 
     it('rejects a non-zip string', () =>
       User.create({ name: 'dude', password: 'ok', billingZip: 'ABCDE' })
-        .then(() => { throw new Error('should have rejected'); })
+        .then(() => {
+          throw new Error('should have rejected');
+        })
         .catch(err => expect(err.name).to.equal('SequelizeValidationError')));
   });
 

--- a/db/seed.js
+++ b/db/seed.js
@@ -3,10 +3,30 @@ import db from './index.js';
 async function seedUsers() {
   return Promise.all(
     [
-      { name: 'Evan', email: 'evan@example.com', password: '1234', isAdmin: true },
-      { name: 'Sean', email: 'sean@example.com', password: '1234', isAdmin: true },
-      { name: 'Rachel', email: 'rachel@example.com', password: '1234', isAdmin: true },
-      { name: 'Test1', email: 'test1@example.com', password: '1234', isAdmin: false },
+      {
+        name: 'Evan',
+        email: 'evan@example.com',
+        password: '1234',
+        isAdmin: true,
+      },
+      {
+        name: 'Sean',
+        email: 'sean@example.com',
+        password: '1234',
+        isAdmin: true,
+      },
+      {
+        name: 'Rachel',
+        email: 'rachel@example.com',
+        password: '1234',
+        isAdmin: true,
+      },
+      {
+        name: 'Test1',
+        email: 'test1@example.com',
+        password: '1234',
+        isAdmin: false,
+      },
     ].map(user => db.model('users').create(user))
   );
 }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "eslint-config-prettier": "^8.10.2",
     "eslint-plugin-react": "^7.37.5",
     "mocha": "^10.8.2",
-    "prettier": "^2.8.8",
+    "prettier": "^3.0.0",
     "sinon": "^22.0.0",
     "sinon-chai": "^3.7.0",
     "supertest": "^7.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,8 +139,8 @@ importers:
         specifier: ^10.8.2
         version: 10.8.2
       prettier:
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^3.0.0
+        version: 3.8.4
       redux-logger:
         specifier: ^3.0.6
         version: 3.0.6
@@ -2686,9 +2686,9 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
+  prettier@3.8.4:
+    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
+    engines: {node: '>=14'}
     hasBin: true
 
   pretty-format@27.5.1:
@@ -6379,7 +6379,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@2.8.8: {}
+  prettier@3.8.4: {}
 
   pretty-format@27.5.1:
     dependencies:

--- a/server/auth.js
+++ b/server/auth.js
@@ -78,7 +78,11 @@ passport.use(
         debug('authenticate user(email: "%s") did fail: bad password');
         return done(null, false, { message: 'Login incorrect' });
       }
-      debug('authenticate user(email: "%s") did ok: user.id=%d', email, user.id);
+      debug(
+        'authenticate user(email: "%s") did ok: user.id=%d',
+        email,
+        user.id
+      );
       done(null, user);
     } catch (err) {
       done(err);

--- a/server/orders.js
+++ b/server/orders.js
@@ -13,8 +13,26 @@ const PRODUCT_INCLUDE = {
 };
 
 async function resolveOrder(order) {
-  const { id, status, shippingRate, shippingCarrier, trackingNumber, created_at, products, total } = order;
-  return { id, status, shippingRate, shippingCarrier, trackingNumber, created_at, products, total: await total };
+  const {
+    id,
+    status,
+    shippingRate,
+    shippingCarrier,
+    trackingNumber,
+    created_at,
+    products,
+    total,
+  } = order;
+  return {
+    id,
+    status,
+    shippingRate,
+    shippingCarrier,
+    trackingNumber,
+    created_at,
+    products,
+    total: await total,
+  };
 }
 
 export default express
@@ -30,7 +48,9 @@ export default express
       } else if (req.user) {
         debug('else if req.user');
         const orders = await req.user.getOrders({ include: [PRODUCT_INCLUDE] });
-        return res.status(200).json(await Promise.all(orders.map(resolveOrder)));
+        return res
+          .status(200)
+          .json(await Promise.all(orders.map(resolveOrder)));
       } else {
         res.status(403).send('Cannot view without req.user');
       }
@@ -51,7 +71,9 @@ export default express
           debug('userId=%s specified as param', req.params.userId);
           const user = await User.findByPk(req.params.userId);
           const order = await user.createOrder(req.body);
-          const products = await Promise.all(productIds.map(id => Product.findByPk(id)));
+          const products = await Promise.all(
+            productIds.map(id => Product.findByPk(id))
+          );
           if (products) {
             products.forEach(product =>
               order.addProduct(product, {
@@ -66,7 +88,9 @@ export default express
         } else {
           debug('no userId param, creating unassociated order');
           const order = await Order.create(req.body);
-          const products = await Promise.all(productIds.map(id => Product.findByPk(id)));
+          const products = await Promise.all(
+            productIds.map(id => Product.findByPk(id))
+          );
           if (products) {
             await Promise.all(
               products.map(product => {
@@ -84,13 +108,17 @@ export default express
               })
             );
           }
-          const fullOrder = await Order.findByPk(order.id, { include: [PRODUCT_INCLUDE] });
+          const fullOrder = await Order.findByPk(order.id, {
+            include: [PRODUCT_INCLUDE],
+          });
           return res.status(200).json(fullOrder);
         }
       } else if (req.user) {
         debug('user is not an admin');
         const order = await req.user.createOrder(req.body);
-        const products = await Promise.all(productIds.map(id => Product.findByPk(id)));
+        const products = await Promise.all(
+          productIds.map(id => Product.findByPk(id))
+        );
         if (products) {
           await Promise.all(
             products.map(product => {
@@ -108,13 +136,17 @@ export default express
             })
           );
         }
-        const fullOrder = await Order.findByPk(order.id, { include: [PRODUCT_INCLUDE] });
+        const fullOrder = await Order.findByPk(order.id, {
+          include: [PRODUCT_INCLUDE],
+        });
         debug('order=%O', fullOrder);
         return res.status(200).json(fullOrder);
       } else {
         debug('no user logged in, creating guest order');
         const order = await Order.create(req.body);
-        const products = await Promise.all(productIds.map(id => Product.findByPk(id)));
+        const products = await Promise.all(
+          productIds.map(id => Product.findByPk(id))
+        );
         if (products) {
           await Promise.all(
             products.map(product =>
@@ -127,7 +159,9 @@ export default express
             )
           );
         }
-        const fullOrder = await Order.findByPk(order.id, { include: [PRODUCT_INCLUDE] });
+        const fullOrder = await Order.findByPk(order.id, {
+          include: [PRODUCT_INCLUDE],
+        });
         return res.status(200).json(fullOrder);
       }
     } catch (err) {
@@ -136,9 +170,12 @@ export default express
   })
 
   .get('/:id', mustBeLoggedIn, async (req, res, next) => {
-    if (!req.user.isAdmin) return forbidden(res, 'You are not authorized to do this.');
+    if (!req.user.isAdmin)
+      return forbidden(res, 'You are not authorized to do this.');
     try {
-      const order = await Order.findByPk(req.params.id, { include: [PRODUCT_INCLUDE] });
+      const order = await Order.findByPk(req.params.id, {
+        include: [PRODUCT_INCLUDE],
+      });
       res.json(await resolveOrder(order));
     } catch (err) {
       next(err);
@@ -146,7 +183,8 @@ export default express
   })
 
   .put('/:id', mustBeLoggedIn, async (req, res, next) => {
-    if (!req.user.isAdmin) return forbidden(res, 'You are not authorized to do this.');
+    if (!req.user.isAdmin)
+      return forbidden(res, 'You are not authorized to do this.');
     try {
       const order = await Order.findByPk(req.params.id);
       const updated = await order.update(req.body);
@@ -157,7 +195,8 @@ export default express
   })
 
   .delete('/:id/', mustBeLoggedIn, async (req, res, next) => {
-    if (!req.user.isAdmin) return forbidden(res, 'You are not authorized to do this.');
+    if (!req.user.isAdmin)
+      return forbidden(res, 'You are not authorized to do this.');
     try {
       const order = await Order.findByPk(req.params.id);
       await order.destroy();
@@ -168,12 +207,15 @@ export default express
   })
 
   .post('/:id/products/', mustBeLoggedIn, async (req, res, next) => {
-    if (!req.user.isAdmin) return forbidden(res, 'You are not authorized to do this.');
+    if (!req.user.isAdmin)
+      return forbidden(res, 'You are not authorized to do this.');
     const orderLineItems = req.body.orderLineItems;
     const productIds = Object.keys(orderLineItems);
     try {
       const order = await Order.findByPk(req.params.id);
-      const products = await Promise.all(productIds.map(id => Product.findByPk(id)));
+      const products = await Promise.all(
+        productIds.map(id => Product.findByPk(id))
+      );
       products.forEach(product =>
         order.addProduct(product, {
           through: {
@@ -188,13 +230,18 @@ export default express
     }
   })
 
-  .delete('/:orderId/products/:productId', mustBeLoggedIn, async (req, res, next) => {
-    if (!req.user.isAdmin) return forbidden(res, 'You are not authorized to do this.');
-    try {
-      const order = await Order.findByPk(req.params.orderId);
-      await order.removeProduct(req.params.productId);
-      res.sendStatus(200);
-    } catch (err) {
-      next(err);
+  .delete(
+    '/:orderId/products/:productId',
+    mustBeLoggedIn,
+    async (req, res, next) => {
+      if (!req.user.isAdmin)
+        return forbidden(res, 'You are not authorized to do this.');
+      try {
+        const order = await Order.findByPk(req.params.orderId);
+        await order.removeProduct(req.params.productId);
+        res.sendStatus(200);
+      } catch (err) {
+        next(err);
+      }
     }
-  });
+  );

--- a/server/users.js
+++ b/server/users.js
@@ -8,7 +8,8 @@ export default express
   .Router()
 
   .get('/', mustBeLoggedIn, async (req, res, next) => {
-    if (!req.user.isAdmin) return forbidden(res, 'only admins can list all users');
+    if (!req.user.isAdmin)
+      return forbidden(res, 'only admins can list all users');
     try {
       const users = await User.findAll();
       res.json(users);


### PR DESCRIPTION
## Summary

- Upgrades `prettier` from `^2.8.8` to `^3.0.0` in `devDependencies`
- `.prettierrc` already had `trailingComma: "es5"` set explicitly, so the v3 default change to `"all"` has no effect
- No prettier plugins are in use, so no `plugins` config addition needed
- Re-ran `pnpm run format` to normalize 6 files with minor style differences from the new major version (`server/auth.js`, `server/orders.js`, `server/users.js`, `db/index.js`, `db/models/user.test.js`, `db/seed.js`)

## Test plan

- [x] `pnpm install` completes without errors
- [x] `pnpm run format:check` passes with no warnings
- [x] `pnpm run build` succeeds

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)