### PR TITLE
dep: replace passport-github2 with passport-github

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "express": "^5.2.1",
     "passport": "^0.7.0",
     "passport-facebook": "^3.0.0",
-    "passport-github2": "^0.1.10",
+    "passport-github": "^1.1.0",
     "passport-google-oauth20": "^2.0.0",
     "passport-local": "^1.0.0",
     "pg": "^8.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,9 @@ importers:
       passport-facebook:
         specifier: ^3.0.0
         version: 3.0.0
-      passport-github2:
-        specifier: ^0.1.10
-        version: 0.1.12
+      passport-github:
+        specifier: ^1.1.0
+        version: 1.1.0
       passport-google-oauth20:
         specifier: ^2.0.0
         version: 2.0.0
@@ -2518,9 +2518,9 @@ packages:
     resolution: {integrity: sha512-K/qNzuFsFISYAyC1Nma4qgY/12V3RSLFdFVsPKXiKZt434wOvthFW1p7zKa1iQihQMRhaWorVE1o3Vi1o+ZgeQ==}
     engines: {node: '>= 0.4.0'}
 
-  passport-github2@0.1.12:
-    resolution: {integrity: sha512-3nPUCc7ttF/3HSP/k9sAXjz3SkGv5Nki84I05kSQPo01Jqq1NzJACgMblCK0fGcv9pKCG/KXU3AJRDGLqHLoIw==}
-    engines: {node: '>= 0.8.0'}
+  passport-github@1.1.0:
+    resolution: {integrity: sha512-XARXJycE6fFh/dxF+Uut8OjlwbFEXgbPVj/+V+K7cvriRK7VcAOm+NgBmbiLM9Qv3SSxEAV+V6fIk89nYHXa8A==}
+    engines: {node: '>= 0.4.0'}
 
   passport-google-oauth20@2.0.0:
     resolution: {integrity: sha512-KSk6IJ15RoxuGq7D1UKK/8qKhNfzbLeLrG3gkLZ7p4A6DBCcv7xpyQwuXtWdpyR0+E0mwkpjY1VfPOhxQrKzdQ==}
@@ -6162,7 +6162,7 @@ snapshots:
     dependencies:
       passport-oauth2: 1.8.0
 
-  passport-github2@0.1.12:
+  passport-github@1.1.0:
     dependencies:
       passport-oauth2: 1.8.0
 

--- a/server/auth.js
+++ b/server/auth.js
@@ -3,7 +3,7 @@ import passport from 'passport';
 import express from 'express';
 import passportFacebook from 'passport-facebook';
 import passportGoogle from 'passport-google-oauth20';
-import passportGithub from 'passport-github2';
+import passportGithub from 'passport-github';
 import passportLocal from 'passport-local';
 import app from '../index.js';
 import User from '../db/models/user.js';


### PR DESCRIPTION
## Summary

- Removes `passport-github2@0.1.12` (last published 2020, single inactive maintainer, **Proprietary** license on npm)
- Adds `passport-github@1.1.0` (canonical MIT-licensed strategy by Jared Hanson, the Passport author)
- One-line import change in `server/auth.js` — the `Strategy` API is identical

## Test plan

- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run format:check` — passes
- [x] `pnpm run build` — succeeds

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)