### PR TITLE
Tighten model types: explicit Sequelize attributes + stricter tsconfig

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Type check
+        run: pnpm typecheck
+
       - name: Test
         run: pnpm test
         env:

--- a/db/models/oauth.ts
+++ b/db/models/oauth.ts
@@ -4,6 +4,7 @@ import type {
   BelongsToGetAssociationMixin,
   BelongsToSetAssociationMixin,
   ModelStatic,
+  Optional,
 } from 'sequelize';
 import type { Profile, Strategy } from 'passport';
 import db from '../sequelize.js';
@@ -21,13 +22,15 @@ type OAuthVerify = (
 
 interface SetupStrategyArgs {
   provider: string;
-  strategy: new (...args: any[]) => Strategy;
+  // Passport strategy constructors vary per provider, so the option shape is
+  // intentionally open here; only the verify callback is pinned down.
+  strategy: new (options: never, verify: OAuthVerify) => Strategy;
   config: Record<string, unknown>;
   oauth?: OAuthVerify;
   passport: { use(strategy: Strategy): unknown };
 }
 
-export interface OAuthInstance extends Model {
+export interface OAuthAttributes {
   uid: string;
   provider: string;
   accessToken: string | null;
@@ -35,7 +38,13 @@ export interface OAuthInstance extends Model {
   token: string | null;
   tokenSecret: string | null;
   profileJson: unknown;
+}
 
+type OAuthCreationAttributes = Optional<OAuthAttributes, keyof OAuthAttributes>;
+
+export interface OAuthInstance
+  extends Model<OAuthAttributes, OAuthCreationAttributes>,
+    OAuthAttributes {
   getUser: BelongsToGetAssociationMixin<UserInstance>;
   setUser: BelongsToSetAssociationMixin<UserInstance, number>;
 }
@@ -102,7 +111,7 @@ OAuth.setupStrategy = ({
     return;
   }
   debug('initializing provider:%s', provider);
-  passport.use(new strategy(config, oauth));
+  passport.use(new strategy(config as never, oauth));
 };
 
 export default OAuth;

--- a/db/models/order.ts
+++ b/db/models/order.ts
@@ -3,18 +3,35 @@ import type {
   BelongsToManyAddAssociationMixin,
   BelongsToManyGetAssociationsMixin,
   BelongsToManyRemoveAssociationMixin,
+  Optional,
 } from 'sequelize';
 import db from '../sequelize.js';
 import type { ProductInstance } from './product.js';
 
-export interface OrderInstance extends Model {
+export interface OrderAttributes {
   id: number;
   status: 'created' | 'processing' | 'cancelled' | 'completed';
-  shippingRate: string;
+  // DECIMAL is read back as a string; writes accept a number or string.
+  shippingRate: number | string;
   shippingCarrier: 'USPS' | 'UPS' | 'FedEx' | null;
   trackingNumber: string | null;
   userId: number | null;
-  created_at?: Date;
+}
+
+type OrderCreationAttributes = Optional<
+  OrderAttributes,
+  | 'id'
+  | 'status'
+  | 'shippingRate'
+  | 'shippingCarrier'
+  | 'trackingNumber'
+  | 'userId'
+>;
+
+export interface OrderInstance
+  extends Model<OrderAttributes, OrderCreationAttributes>,
+    OrderAttributes {
+  readonly created_at?: Date;
 
   // Eager-loaded association + computed async getter (see getterMethods below).
   products?: ProductInstance[];
@@ -25,7 +42,7 @@ export interface OrderInstance extends Model {
   removeProduct: BelongsToManyRemoveAssociationMixin<ProductInstance, number>;
 }
 
-const Order = db.define<OrderInstance>(
+const Order = db.define<OrderInstance, Omit<OrderAttributes, 'id' | 'userId'>>(
   'orders',
   {
     status: {
@@ -58,7 +75,7 @@ const Order = db.define<OrderInstance>(
           products.forEach(
             product => (runningTotal += product.orderLineItems!.subtotal)
           );
-          runningTotal += parseFloat(this.shippingRate);
+          runningTotal += Number(this.shippingRate);
           console.log(runningTotal);
           return runningTotal;
         });

--- a/db/models/orderLineItem.ts
+++ b/db/models/orderLineItem.ts
@@ -1,9 +1,15 @@
 import { DataTypes, Model } from 'sequelize';
 import db from '../sequelize.js';
 
-export interface OrderLineItemInstance extends Model {
+export interface OrderLineItemAttributes {
   quantity: number;
-  price: string;
+  // DECIMAL is read back as a string; writes accept a number or string.
+  price: number | string;
+}
+
+export interface OrderLineItemInstance
+  extends Model<OrderLineItemAttributes, OrderLineItemAttributes>,
+    OrderLineItemAttributes {
   readonly subtotal: number;
 }
 

--- a/db/models/product.ts
+++ b/db/models/product.ts
@@ -1,54 +1,68 @@
 import { DataTypes, Model } from 'sequelize';
+import type { Optional } from 'sequelize';
 import db from '../sequelize.js';
 import type { OrderLineItemInstance } from './orderLineItem.js';
 
-export interface ProductInstance extends Model {
+export interface ProductAttributes {
   id: number;
   name: string;
   description: string;
-  price: string;
+  // DECIMAL is read back as a string; writes accept a number or string.
+  price: number | string;
   quantity: number;
   photo: string | null;
   categories: string[] | null;
+}
 
+type ProductCreationAttributes = Optional<
+  ProductAttributes,
+  'id' | 'photo' | 'categories'
+>;
+
+export interface ProductInstance
+  extends Model<ProductAttributes, ProductCreationAttributes>,
+    ProductAttributes {
   // Present on products eager-loaded through an order's many-to-many join.
   orderLineItems?: OrderLineItemInstance;
 }
 
-const Product = db.define<ProductInstance>('products', {
-  name: {
-    type: DataTypes.STRING,
-    allowNull: false,
-    validate: {
-      notEmpty: true,
+const Product = db.define<ProductInstance, Omit<ProductAttributes, 'id'>>(
+  'products',
+  {
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      validate: {
+        notEmpty: true,
+      },
     },
-  },
-  description: {
-    type: DataTypes.TEXT,
-    allowNull: false,
-    validate: {
-      notEmpty: true,
+    description: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      validate: {
+        notEmpty: true,
+      },
     },
-  },
-  price: {
-    type: DataTypes.DECIMAL(16, 2),
-    allowNull: false,
-    validate: {
-      notEmpty: true,
+    price: {
+      type: DataTypes.DECIMAL(16, 2),
+      allowNull: false,
+      validate: {
+        notEmpty: true,
+      },
     },
-  },
-  quantity: {
-    type: DataTypes.INTEGER,
-    allowNull: false,
-    validate: {
-      notEmpty: true,
-      min: 0,
+    quantity: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      validate: {
+        notEmpty: true,
+        min: 0,
+      },
     },
-  },
-  photo: {
-    type: DataTypes.STRING,
-  },
-  categories: DataTypes.ARRAY(DataTypes.STRING),
-});
+    photo: {
+      type: DataTypes.STRING,
+    },
+    categories: DataTypes.ARRAY(DataTypes.STRING),
+  }
+);
 
 export default Product;

--- a/db/models/review.test.ts
+++ b/db/models/review.test.ts
@@ -8,6 +8,7 @@ describe('Review', () => {
   describe('Persistence to the db', () => {
     xit('Does not allow a title to be null', () =>
       Review.create({
+        // @ts-expect-error intentionally passing null to verify the DB rejects it
         title: null,
         body: 'oops!',
         rating: 3,

--- a/db/models/review.ts
+++ b/db/models/review.ts
@@ -1,17 +1,30 @@
 import { DataTypes, Model } from 'sequelize';
+import type { Optional } from 'sequelize';
 import db from '../sequelize.js';
 
-export interface ReviewInstance extends Model {
+export interface ReviewAttributes {
   id: number;
   title: string;
   body: string | null;
   rating: number;
   photo: string | null;
-  userId: number | null;
   productId: number | null;
+  userId: number | null;
 }
 
-const Review = db.define<ReviewInstance>(
+type ReviewCreationAttributes = Optional<
+  ReviewAttributes,
+  'id' | 'body' | 'photo' | 'productId' | 'userId'
+>;
+
+export interface ReviewInstance
+  extends Model<ReviewAttributes, ReviewCreationAttributes>,
+    ReviewAttributes {}
+
+const Review = db.define<
+  ReviewInstance,
+  Omit<ReviewAttributes, 'id' | 'productId' | 'userId'>
+>(
   'reviews',
   {
     title: {

--- a/db/models/user.ts
+++ b/db/models/user.ts
@@ -3,11 +3,12 @@ import { DataTypes, Model } from 'sequelize';
 import type {
   HasManyCreateAssociationMixin,
   HasManyGetAssociationsMixin,
+  Optional,
 } from 'sequelize';
 import db from '../sequelize.js';
 import type { OrderInstance } from './order.js';
 
-export interface UserInstance extends Model {
+export interface UserAttributes {
   id: number;
   name: string;
   email: string | null;
@@ -24,14 +25,38 @@ export interface UserInstance extends Model {
   resetPassword: boolean | null;
   isAdmin: boolean;
   role: 'unauth' | 'auth';
+}
 
+// Everything except `name` is optional at creation (auto / defaulted / nullable).
+type UserCreationAttributes = Optional<
+  UserAttributes,
+  | 'id'
+  | 'email'
+  | 'billingAddress'
+  | 'billingCity'
+  | 'billingState'
+  | 'billingZip'
+  | 'shippingAddress'
+  | 'shippingCity'
+  | 'shippingState'
+  | 'shippingZip'
+  | 'password_digest'
+  | 'password'
+  | 'resetPassword'
+  | 'isAdmin'
+  | 'role'
+>;
+
+export interface UserInstance
+  extends Model<UserAttributes, UserCreationAttributes>,
+    UserAttributes {
   authenticate(plaintext: string): Promise<boolean>;
 
   getOrders: HasManyGetAssociationsMixin<OrderInstance>;
   createOrder: HasManyCreateAssociationMixin<OrderInstance>;
 }
 
-const User = db.define<UserInstance>(
+const User = db.define<UserInstance, Omit<UserAttributes, 'id'>>(
   'users',
   {
     name: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,10 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react",
-    "types": ["node", "mocha"]
+    "types": ["node", "mocha"],
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true
   },
   "include": ["app/**/*", "server/**/*", "db/**/*", "index.ts"],
   "exclude": ["node_modules", "**/*.test.jsx"]


### PR DESCRIPTION
Follow-up to the TypeScript migration (#297), tightening the loosest remaining types.

## What & why

The migration deliberately typed the Sequelize models with `extends Model` (i.e. `Model<any, any>`) to keep scope contained. The cost: `.create()`, `.update()`, and `where` clauses accepted **anything** — typos in attribute names and wrong value types went uncaught.

This gives each model an explicit `Attributes` / `CreationAttributes` interface:

```ts
export interface ReviewAttributes { id: number; title: string; rating: number; /* … */ }
type ReviewCreationAttributes = Optional<ReviewAttributes, 'id' | 'body' | 'photo' | 'productId' | 'userId'>;
export interface ReviewInstance extends Model<ReviewAttributes, ReviewCreationAttributes>, ReviewAttributes {}
```

The one wrinkle with `db.define` is that Sequelize auto-manages the `id`, timestamp, and association FK columns, which aren't in the column-definitions object. Rather than declare those explicitly (risking conflicts with the auto-managed ones), the column object is decoupled from the attribute set:

```ts
const Review = db.define<ReviewInstance, Omit<ReviewAttributes, 'id' | 'productId' | 'userId'>>('reviews', { /* columns unchanged */ });
```

So **the column definitions and the tests are untouched**, but `Review.create({...})` / `Review.findOne({ where })` are now checked against the real attributes.

This isn't theoretical — it immediately caught a pending test passing `title: null` to a `allowNull: false` column (kept as an explicit `@ts-expect-error`, since it documents a real runtime guard for untyped `req.body` input).

## Also in this PR

- **Removed the lone explicit `any`** in `oauth.ts` — the passport verify callback is now typed (`OAuthVerify`); the per-provider strategy *option* shape stays an explicit dynamic boundary rather than `any[]`.
- **Three stricter compiler flags**, all with zero fallout:
  - `noUncheckedIndexedAccess` — indexed access yields `T | undefined` (the valuable one)
  - `noImplicitOverride`
  - `noFallthroughCasesInSwitch`
  - (Skipped `noImplicitReturns` / `noPropertyAccessFromIndexSignature` — ~20 errors each from the Express `return res.send()` handler idiom and `env.X` access; not worth the churn.)

## Notes / non-goals

- DECIMAL columns are typed `number | string` (Sequelize reads them back as strings but accepts numbers on write); read-side arithmetic uses `Number(...)`.
- Did **not** type `req.body` per-route or remove the `!` assertions behind `mustBeLoggedIn` — those are a larger, separate pass; happy to do it if wanted.

## Verification

- `tsc --noEmit` clean (with the new flags)
- `eslint` 0 errors (22 pre-existing warnings, unchanged)
- `pnpm test` deterministically green — 48 passing, 0 failing, across repeated runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
