### PR TITLE
fix(db): only createdb on missing-db error, surface original sync error

### DIFF
--- a/db/index.ts
+++ b/db/index.ts
@@ -7,33 +7,55 @@ import './models/index.js';
 
 const execAsync = promisify(exec);
 
+// Postgres error code 3D000: "invalid_catalog_name" — database does not exist.
+function isMissingDbError(err: unknown): boolean {
+  return (err as any)?.original?.code === '3D000';
+}
+
 async function sync(
   force = app.isTesting,
   retries = 0,
   maxRetries = 5
 ): Promise<void> {
+  let syncError: unknown;
   try {
     await db.sync({ force });
     console.log(`Synced models to db ${dbUrl}`);
+    return;
   } catch (fail) {
-    if (app.isProduction || retries > maxRetries) {
-      console.error(styleText('red', `********** database error ***********`));
-      console.error(styleText('red', `    Couldn't connect to ${dbUrl}`));
-      console.error();
-      console.error(styleText('red', String(fail)));
-      console.error(styleText('red', `*************************************`));
-      return;
-    }
-    console.log(
-      `${retries ? `[retry ${retries}]` : ''} Creating database ${dbName}...`
-    );
-    await execAsync(`createdb "${dbName}"`);
-    await sync(true, retries + 1);
+    syncError = fail;
   }
+
+  if (app.isProduction || retries > maxRetries) {
+    console.error(styleText('red', `********** database error ***********`));
+    console.error(styleText('red', `    Couldn't connect to ${dbUrl}`));
+    console.error();
+    console.error(styleText('red', String(syncError)));
+    console.error(styleText('red', `*************************************`));
+    return;
+  }
+
+  if (!isMissingDbError(syncError)) {
+    throw syncError;
+  }
+
+  console.log(
+    `${retries ? `[retry ${retries}]` : ''} Creating database ${dbName}...`
+  );
+  try {
+    await execAsync(`createdb "${dbName}"`);
+  } catch {
+    throw syncError;
+  }
+  await sync(true, retries + 1);
 }
 
 // Guard against the module being evaluated more than once (see sequelize.ts):
 // only kick off a single sync on the shared instance.
-db.didSync ||= sync();
+if (!db.didSync) {
+  const p = sync();
+  p.catch(() => {}); // prevent unhandledRejection before consumers await db.didSync
+  db.didSync = p;
+}
 
 export default db;


### PR DESCRIPTION
## Summary

Fixes the three issues identified in #296 where `db/index.ts` masked `db.sync()` errors via an unconditional `createdb` fallback.

- **Scoped fallback**: `createdb` is now only invoked when the Sequelize error carries Postgres code `3D000` (database does not exist). Any other failure — auth, schema mismatch, connection refused — is rethrown immediately with the real error instead of cascading into a confusing `createdb` / `ENOENT` failure.
- **`createdb` failure surfacing**: `execAsync` is wrapped in its own try/catch; if `createdb` is absent or fails for any reason, the original `db.sync()` error is thrown so the root cause is always visible.
- **Unhandled rejection suppression**: replaced `db.didSync ||= sync()` with an explicit `if`-block that calls `p.catch(() => {})` on the promise before storing it. This prevents Node from emitting `unhandledRejection` during the window between module load and when consumers (e.g. `before('wait for the db', () => db.didSync)` in model tests) await it, while still allowing the rejection to propagate to those consumers.

## Test plan

- [ ] `pnpm test` passes with a reachable Postgres where the target database already exists
- [ ] Starting the server against a missing database still triggers the `createdb` fallback and retries correctly
- [ ] With `createdb` removed from PATH and a reachable Postgres (database already exists), `pnpm test` no longer produces flaky failures — the original `db.sync()` error is surfaced instead of an `ENOENT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)