### PR TITLE
fix: GET /api/users/:id returns empty body (router.param multi-handler bug)

### DIFF
--- a/server/users.test.ts
+++ b/server/users.test.ts
@@ -2,10 +2,22 @@ import request from 'supertest';
 import { expect } from 'chai';
 import db from '../db/index.js';
 import User from '../db/models/user.js';
+import type { UserInstance } from '../db/models/user.js';
 import app from './start.js';
+
+const alice = { name: 'Alice', email: 'alice@example.com', password: '12345' };
+const bob = { name: 'Bob', email: 'bob@example.com', password: '12345' };
+const adminUser = {
+  name: 'Admin',
+  email: 'admin@example.com',
+  password: '12345',
+  isAdmin: true,
+};
 
 describe('/api/users', () => {
   describe('when not logged in', () => {
+    before(() => db.didSync);
+
     it('GET /:id fails 401 (Unauthorized)', () =>
       request(app).get(`/api/users/1`).expect(401));
 
@@ -32,5 +44,99 @@ describe('/api/users', () => {
             email: 'eve@interloper.com',
           })
         ));
+  });
+
+  describe('GET /:id', () => {
+    describe('as the owner', () => {
+      const agent = request.agent(app);
+      let user: UserInstance;
+      before(() =>
+        db.didSync
+          .then(() => User.create(alice))
+          .then(_user => {
+            user = _user;
+            return agent
+              .post('/api/auth/local/login')
+              .send({ username: alice.email, password: alice.password });
+          })
+      );
+      after(() => user.destroy());
+
+      it('returns 200 with the user body', () =>
+        agent
+          .get(`/api/users/${user.id}`)
+          .expect(200)
+          .then(res => {
+            expect(res.body).to.be.an('object');
+            expect(res.body.id).to.equal(user.id);
+            expect(res.body.email).to.equal(alice.email);
+          }));
+    });
+
+    describe('as a different non-admin user', () => {
+      const agent = request.agent(app);
+      let userA: UserInstance, userB: UserInstance;
+      before(() =>
+        db.didSync
+          .then(() => Promise.all([User.create(alice), User.create(bob)]))
+          .then(([a, b]) => {
+            userA = a;
+            userB = b;
+            return agent
+              .post('/api/auth/local/login')
+              .send({ username: bob.email, password: bob.password });
+          })
+      );
+      after(() => Promise.all([userA.destroy(), userB.destroy()]));
+
+      it('returns 403 Forbidden', () =>
+        agent.get(`/api/users/${userA.id}`).expect(403));
+    });
+
+    describe('as an admin', () => {
+      const agent = request.agent(app);
+      let user: UserInstance, admin: UserInstance;
+      before(() =>
+        db.didSync
+          .then(() => Promise.all([User.create(alice), User.create(adminUser)]))
+          .then(([_user, _admin]) => {
+            user = _user;
+            admin = _admin;
+            return agent.post('/api/auth/local/login').send({
+              username: adminUser.email,
+              password: adminUser.password,
+            });
+          })
+      );
+      after(() => Promise.all([user.destroy(), admin.destroy()]));
+
+      it('returns 200 with the requested user body', () =>
+        agent
+          .get(`/api/users/${user.id}`)
+          .expect(200)
+          .then(res => {
+            expect(res.body).to.be.an('object');
+            expect(res.body.id).to.equal(user.id);
+          }));
+    });
+
+    describe('for a non-existent id', () => {
+      const agent = request.agent(app);
+      let user: UserInstance;
+      before(() =>
+        db.didSync
+          .then(() => User.create(alice))
+          .then(_user => {
+            user = _user;
+            return agent
+              .post('/api/auth/local/login')
+              .send({ username: alice.email, password: alice.password });
+          })
+      );
+      after(() => user.destroy());
+
+      it('returns 404', () =>
+        agent.get('/api/users/99999999').expect(404));
+    });
   });
 });

--- a/server/users.ts
+++ b/server/users.ts
@@ -31,19 +31,13 @@ export default express
     }
   })
 
-  // NOTE: Express's router.param only invokes the first handler, so the async
-  // lookup below never runs (req.foundUser is left unset) — preserved as-is
-  // from the original JavaScript to keep behavior identical.
-  // @ts-expect-error router.param accepts a single handler, not middleware + handler
-  .param('id', mustBeLoggedIn, async function (req, res, next) {
+  .param('id', async (req, res, next) => {
+    if (!req.user) return res.status(401).send('You must be logged in');
     try {
       const user = await User.findByPk(String(req.params.id));
-      if (user) {
-        req.foundUser = user;
-        next();
-      } else {
-        res.sendStatus(404);
-      }
+      if (!user) return res.sendStatus(404);
+      req.foundUser = user;
+      next();
     } catch (err) {
       next(err);
     }


### PR DESCRIPTION
## Summary

Fixes #295.

`router.param()` in Express accepts only a **single** callback. The original code passed `mustBeLoggedIn` as a second argument, which Express silently ignored — meaning the `async` function that assigns `req.foundUser` never ran. Every authenticated `GET /api/users/:id` request received an empty (`undefined`) body.

**Root cause:**
```js
// Before — second callback is silently dropped by Express
.param('id', mustBeLoggedIn, async (req, res, next) => {
  req.foundUser = await User.findByPk(req.params.id); // never ran
  ...
})
```

**Fix:** collapse to a single `param` callback that checks auth first (preserving the original 401-before-404 security ordering), then performs the DB lookup. Move the ownership/admin check to the route handler.

```js
// After
.param('id', async (req, res, next) => {
  if (!req.user) return res.status(401).send('You must be logged in');
  const user = await User.findByPk(String(req.params.id));
  if (!user) return res.sendStatus(404);
  req.foundUser = user;
  next();
})
.get('/:id', (req, res) => {
  if (!req.user!.isAdmin && String(req.user!.id) !== String(req.params.id))
    return forbidden(res, 'You may only view your own profile');
  res.status(200).json(req.foundUser); // now populated
});
```

## Changes

- **`server/users.ts`** — fix the broken `router.param` call; auth check is now first in the single callback so unauthenticated requests still get 401 before any DB query runs
- **`server/users.test.ts`** — add `before(db.didSync)` to the "when not logged in" suite; add 4 new authenticated-path tests (owner → 200, cross-user → 403, admin → 200, non-existent ID → 404)

## Test plan

- [ ] `npm test -- --grep "api/users"` — all 6 tests pass, 1 pre-existing `xit` skip
- [ ] `GET /api/users/:id` as the owner returns the full user JSON (not an empty body)
- [ ] Unauthenticated `GET /api/users/:id` still returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)