### PR TITLE
ci: add least-privilege workflow permissions (CodeQL #1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+# Least-privilege default: this workflow only checks out and tests the code.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves CodeQL alert #1 — **Workflow does not contain permissions** (`actions/missing-workflow-permissions`, `.github/workflows/ci.yml`).

The CI workflow declared no `permissions` block, so its `GITHUB_TOKEN` inherits the repository-default scope (often read/write). This job only checks out the repo and runs lint / typecheck / tests, so it needs nothing beyond read access.

Added a least-privilege top-level block:

```yaml
permissions:
  contents: read
```

No behavior change — checkout, install, lint, typecheck, and test need only `contents: read`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
