### PR TITLE
fix(oauth): stop logging name/uid in clear text (CodeQL #6)

### DIFF
--- a/db/models/oauth.ts
+++ b/db/models/oauth.ts
@@ -78,12 +78,9 @@ OAuth.V2 = async (accessToken, refreshToken, profile, done) => {
     const [oauth] = await OAuth.findOrCreate({
       where: { provider: profile.provider, uid: profile.id },
     });
-    debug(
-      'provider:%s will log in user:{name=%s uid=%s}',
-      profile.provider,
-      profile.displayName,
-      oauth.uid
-    );
+    // Log only the provider — never the user's name or the OAuth uid, which are
+    // personal data and would be written to logs in clear text.
+    debug('oauth login via provider:%s', profile.provider);
     oauth.profileJson = profile;
     // Run getUser and save in parallel; only the user result is needed downstream
     const [existingUser] = await Promise.all([oauth.getUser(), oauth.save()]);


### PR DESCRIPTION
Resolves CodeQL alert #6 — **Clear-text logging of sensitive information** (`js/clear-text-logging`, `db/models/oauth.ts`).

The OAuth `V2` login handler logged the user's display name and provider uid:

```ts
debug(
  'provider:%s will log in user:{name=%s uid=%s}',
  profile.provider,
  profile.displayName,   // personal data
  oauth.uid,             // provider account id
);
```

Both are personal data written to logs in clear text. Replaced with a log of just the provider:

```ts
debug('oauth login via provider:%s', profile.provider);
```

Verified `pnpm typecheck` and `pnpm lint` pass. No behavior change beyond the log contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
