### PR TITLE
fix(auth): rate-limit signup and login (CodeQL #3, #4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "cookie-session": "^2.1.1",
     "debug": "^4.0.0",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.5.2",
     "passport": "^0.7.0",
     "passport-github": "^1.1.0",
     "passport-local": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      express-rate-limit:
+        specifier: ^8.5.2
+        version: 8.5.2(express@5.2.1)
       passport:
         specifier: ^0.7.0
         version: 0.7.0
@@ -1320,6 +1323,12 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
@@ -1533,6 +1542,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -3970,6 +3983,11 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
@@ -4225,6 +4243,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.4
       side-channel: 1.1.0
+
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,6 +1,7 @@
 import createDebug from 'debug';
 import passport from 'passport';
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 import passportGithub from 'passport-github';
 import passportLocal from 'passport-local';
 import app from '../index.js';
@@ -10,6 +11,15 @@ import OAuth from '../db/models/oauth.js';
 const { env } = app;
 const debug = createDebug(`${app.name}:auth`);
 const auth = express.Router();
+
+// Throttle the credential endpoints (signup/login) to blunt brute-force and
+// account-enumeration attempts. Generous enough not to affect normal use.
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 OAuth.setupStrategy({
   provider: 'github',
@@ -68,7 +78,7 @@ passport.use(
 
 auth.get('/whoami', (req, res) => res.send(req.user));
 
-auth.post('/local/signup', async (req, res, next) => {
+auth.post('/local/signup', authLimiter, async (req, res, next) => {
   if (req.user) return res.status(403).send('Already logged in');
   const { name, email, password } = req.body;
   try {
@@ -82,7 +92,7 @@ auth.post('/local/signup', async (req, res, next) => {
   }
 });
 
-auth.post('/:strategy/login', (req, res, next) =>
+auth.post<{ strategy: string }>('/:strategy/login', authLimiter, (req, res, next) =>
   passport.authenticate(req.params.strategy, {
     successRedirect: '/',
   })(req, res, next)


### PR DESCRIPTION
Resolves CodeQL alerts **#3** and **#4** — **Missing rate limiting** (`js/missing-rate-limiting`) on `server/auth.ts`:
- `POST /local/signup` (creates a user)
- `POST /:strategy/login` (authenticates credentials)

Both are unauthenticated and hit the database, so without throttling they're exposed to brute-force and account-enumeration. Both alerts are the same remediation in the same file, so they're addressed together (separate PRs would conflict).

### Change
Added an `express-rate-limit` middleware and applied it to both credential endpoints:

```ts
const authLimiter = rateLimit({
  windowMs: 15 * 60 * 1000,
  max: 100,
  standardHeaders: true,
  legacyHeaders: false,
});

auth.post('/local/signup', authLimiter, /* ... */);
auth.post<{ strategy: string }>('/:strategy/login', authLimiter, /* ... */);
```

The login route gains an explicit `<{ strategy: string }>` params generic: with a second handler in the chain, Express 5 stops inferring the param from the path literal, so `req.params.strategy` would otherwise widen to `string | undefined` (under `noUncheckedIndexedAccess`) and fail to typecheck against `passport.authenticate`.

The limit (100 / 15 min / IP) is well above normal interactive use.

### Verification
`pnpm typecheck`, `pnpm lint` (0 errors), and the auth + users test suites all pass.

> Note: behind a reverse proxy in production you'll also want `app.set('trust proxy', …)` so the limiter keys on the real client IP — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
