### PR TITLE
chore(deps): override vulnerable form-data/undici/uuid (−8 Dependabot alerts)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  form-data: ^4.0.6
+  undici: ^7.28.0
+  uuid: ^11.1.1
+
 importers:
 
   .:
@@ -1389,8 +1394,8 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   formidable@3.5.4:
@@ -2556,8 +2561,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.27.2:
-    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unpipe@1.0.0:
@@ -2579,9 +2584,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   validator@13.15.35:
@@ -3264,7 +3268,7 @@ snapshots:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
       '@types/node': 25.9.1
-      form-data: 4.0.5
+      form-data: 4.0.6
 
   '@types/supertest@7.2.0':
     dependencies:
@@ -3527,7 +3531,7 @@ snapshots:
   axios@1.16.1(debug@4.4.3):
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3)
-      form-data: 4.0.5
+      form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -4070,7 +4074,7 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -4392,7 +4396,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.27.2
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -4995,7 +4999,7 @@ snapshots:
       semver: 7.8.1
       sequelize-pool: 7.1.0
       toposort-class: 1.0.1
-      uuid: 8.3.2
+      uuid: 11.1.1
       validator: 13.15.35
       wkx: 0.5.0
     optionalDependencies:
@@ -5169,7 +5173,7 @@ snapshots:
       cookiejar: 2.1.4
       debug: 4.4.3
       fast-safe-stringify: 2.1.1
-      form-data: 4.0.5
+      form-data: 4.0.6
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
@@ -5304,7 +5308,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.27.2: {}
+  undici@7.28.0: {}
 
   unpipe@1.0.0: {}
 
@@ -5320,7 +5324,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@8.3.2: {}
+  uuid@11.1.1: {}
 
   validator@13.15.35: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,11 @@
 allowBuilds:
   bcrypt: true
   esbuild: true
+
+# Force patched versions of vulnerable transitive dependencies (Dependabot).
+# Stay within the majors the dependents expect: jsdom 29 needs undici 7.x, and
+# uuid is bumped only as far as the first patched release.
+overrides:
+  form-data: '^4.0.6'
+  undici: '^7.28.0'
+  uuid: '^11.1.1'


### PR DESCRIPTION
Pins patched versions of three vulnerable **transitive** dependencies in `pnpm-lock.yaml`, resolving **8 Dependabot alerts**.

pnpm 11 no longer reads `pnpm.overrides` from `package.json`, so the overrides live in `pnpm-workspace.yaml`:

```yaml
overrides:
  form-data: '^4.0.6'
  undici: '^7.28.0'
  uuid: '^11.1.1'
```

| Package | From → To | Pulled in by | Alerts |
|---|---|---|---|
| `form-data` | 4.0.5 → 4.0.6 | `axios` (runtime) | CRLF injection (#14/#27) |
| `undici` | 7.27.2 → 7.28.0 | `jsdom` (dev/test) | 6 CVEs (#28–#34) |
| `uuid` | 8.3.2 → 11.1.1 | `sequelize` (runtime) | buffer bounds check (#11/#23) |

### Why these exact ranges
- **`undici` kept in 7.x** — `jsdom@29` imports `undici/lib/handler/wrap-handler.js`, an internal path that exists in 7.x but was moved in 8.x. A `>=7.28.0` (latest-major) override pulled `undici@8.5.0` and broke every jsdom test; `^7.28.0` fixes the CVEs while staying compatible.
- **`uuid` bumped only to the first patched release** (11.1.1). Sequelize uses uuid v1/v4 (not the v3/v5/v6 + `buf` path the advisory concerns), and the db test suite confirms model creation still works.

### Verification
`pnpm typecheck`, `pnpm build`, and the full test suite (**52 passed, 2 skipped**) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
