### PR TITLE
Update TypeScript target and ESLint ecmaVersion to ES2025

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "target": "ES2025",
+    "lib": ["DOM", "DOM.Iterable", "ES2025"],
     "module": "ESNext",
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- Update TypeScript `target` to `ES2025` in all tsconfig files
- Update `lib` arrays to reference `ES2025` instead of older ES versions
- Update ESLint `ecmaVersion` to `2025` where applicable

## Test plan
- [ ] Run `npm run typecheck` (or `pnpm run typecheck`) to verify TypeScript accepts the new target
- [ ] Run `npm run lint` to verify ESLint accepts `ecmaVersion: 2025`

🤖 Generated with [Claude Code](https://claude.com/claude-code)