### PR TITLE
Replace axios with native fetch

### DIFF
--- a/app/api.ts
+++ b/app/api.ts
@@ -1,0 +1,27 @@
+// Tiny wrappers around the native `fetch` API for same-origin JSON requests.
+
+async function toError(res: Response): Promise<Error> {
+  let message = `HTTP ${res.status}`;
+  try {
+    const data = await res.clone().json();
+    if (data?.message) message = data.message;
+  } catch {
+    /* response had no JSON body */
+  }
+  return new Error(message);
+}
+
+export async function getJSON<T = unknown>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) throw await toError(res);
+  return res.json();
+}
+
+export async function postJSON(url: string, body?: unknown): Promise<void> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: body === undefined ? undefined : { 'Content-Type': 'application/json' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  if (!res.ok) throw await toError(res);
+}

--- a/app/components/App.tsx
+++ b/app/components/App.tsx
@@ -1,16 +1,19 @@
 import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { Outlet } from 'react-router-dom';
-import axios from 'axios';
+import { getJSON } from '../api';
 import { receiveProducts } from '../reducers/products';
 import Footer from './Footer';
 import NavContainer from '../containers/NavContainer';
 import type { AppDispatch } from '../store';
+import type { Product } from '../types';
 
 export default function App() {
   const dispatch = useDispatch<AppDispatch>();
   useEffect(() => {
-    axios.get('/api/products').then(res => dispatch(receiveProducts(res.data)));
+    getJSON<Product[]>('/api/products')
+      .then(products => dispatch(receiveProducts(products)))
+      .catch(err => console.error(err));
   }, []);
   return (
     <div id="main" className="container-fluid">

--- a/app/reducers/auth.ts
+++ b/app/reducers/auth.ts
@@ -1,5 +1,5 @@
 import { createSlice, createAction, PayloadAction } from '@reduxjs/toolkit';
-import axios from 'axios';
+import { getJSON, postJSON } from '../api';
 import type { AppDispatch } from '../store';
 import type { User } from '../types';
 
@@ -17,28 +17,24 @@ const authSlice = createSlice({
 export const { authenticated } = authSlice.actions;
 
 export const whoami = () => (dispatch: AppDispatch) =>
-  axios
-    .get('/api/auth/whoami')
-    .then(response => dispatch(authenticated(response.data)))
+  getJSON<User | null>('/api/auth/whoami')
+    .then(user => dispatch(authenticated(user)))
     .catch(() => dispatch(authenticated(null)));
 
 export const login =
   (username: string, password: string) => (dispatch: AppDispatch) =>
-    axios
-      .post('/api/auth/local/login', { username, password })
+    postJSON('/api/auth/local/login', { username, password })
       .then(() => dispatch(whoami()))
       .catch(() => dispatch(whoami()));
 
 export const signup =
   (name: string, email: string, password: string) => (dispatch: AppDispatch) =>
-    axios
-      .post('/api/auth/local/signup', { name, email, password })
+    postJSON('/api/auth/local/signup', { name, email, password })
       .then(() => dispatch(whoami()))
       .catch(() => dispatch(whoami()));
 
 export const logout = () => (dispatch: AppDispatch) =>
-  axios
-    .post('/api/auth/logout')
+  postJSON('/api/auth/logout')
     .then(() => {
       dispatch(whoami());
       dispatch(wipeLocalState());

--- a/app/reducers/orders.ts
+++ b/app/reducers/orders.ts
@@ -1,5 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import axios from 'axios';
+import { getJSON, postJSON } from '../api';
 import { emptyCart } from './cart';
 import type { AppDispatch } from '../store';
 import type { CartItem, Order } from '../types';
@@ -42,9 +42,8 @@ export const { selectOrder, setOrderSuccess, setOrderError } =
   ordersSlice.actions;
 
 export const receiveOrders = () => (dispatch: AppDispatch) =>
-  axios
-    .get('/api/orders/')
-    .then(res => dispatch(ordersSlice.actions.setOrders(res.data)))
+  getJSON<Order[]>('/api/orders/')
+    .then(orders => dispatch(ordersSlice.actions.setOrders(orders)))
     .catch(err => console.error(err));
 
 export function submitOrder(cart: CartItem[], navigate?: NavigateFunction) {
@@ -54,8 +53,7 @@ export function submitOrder(cart: CartItem[], navigate?: NavigateFunction) {
   });
   const order = { shippingCarrier: 'UPS', orderLineItems };
   return (dispatch: AppDispatch) =>
-    axios
-      .post('/api/orders/', order)
+    postJSON('/api/orders/', order)
       .then(() => {
         dispatch(setOrderSuccess('Cookies are on the way!'));
         dispatch(emptyCart());
@@ -63,9 +61,7 @@ export function submitOrder(cart: CartItem[], navigate?: NavigateFunction) {
       })
       .catch(err => {
         const message =
-          err?.response?.data?.message ||
-          err?.message ||
-          'Order submission failed. Please try again.';
+          err?.message || 'Order submission failed. Please try again.';
         console.error('Order submission error:', err);
         dispatch(setOrderError(message));
       });

--- a/app/reducers/users.ts
+++ b/app/reducers/users.ts
@@ -1,5 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import axios from 'axios';
+import { getJSON } from '../api';
 import { wipeLocalState } from './auth';
 import type { AppDispatch } from '../store';
 import type { User } from '../types';
@@ -30,9 +30,8 @@ const usersSlice = createSlice({
 export const { selectUser } = usersSlice.actions;
 
 export const receiveUsers = () => (dispatch: AppDispatch) =>
-  axios
-    .get('/api/users/')
-    .then(res => dispatch(usersSlice.actions.setUsers(res.data)))
+  getJSON<User[]>('/api/users/')
+    .then(users => dispatch(usersSlice.actions.setUsers(users)))
     .catch(err => console.error(err));
 
 export default usersSlice.reducer;

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@fortawesome/free-solid-svg-icons": "^7.2.0",
     "@fortawesome/react-fontawesome": "^3.3.1",
     "@reduxjs/toolkit": "^2.8.2",
-    "axios": "^1.18.0",
     "bcryptjs": "^3.0.3",
     "cookie-session": "^2.1.1",
     "debug": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,9 +25,6 @@ importers:
       '@reduxjs/toolkit':
         specifier: ^2.8.2
         version: 2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)
-      axios:
-        specifier: ^1.18.0
-        version: 1.18.0(debug@4.4.3)
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -892,10 +889,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
-
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
@@ -958,9 +951,6 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
-
-  axios@1.18.0:
-    resolution: {integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1343,15 +1333,6 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.16.0:
-    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
@@ -1452,10 +1433,6 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
-
-  https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -2017,10 +1994,6 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
-
-  proxy-from-env@2.1.0:
-    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
-    engines: {node: '>=10'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3251,12 +3224,6 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  agent-base@6.0.2:
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -3347,16 +3314,6 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
-
-  axios@1.18.0(debug@4.4.3):
-    dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3)
-      form-data: 4.0.6
-      https-proxy-agent: 5.0.1
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
 
   balanced-match@1.0.2: {}
 
@@ -3870,10 +3827,6 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.16.0(debug@4.4.3):
-    optionalDependencies:
-      debug: 4.4.3
-
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
@@ -3988,13 +3941,6 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
-
-  https-proxy-agent@5.0.1:
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   iconv-lite@0.7.2:
     dependencies:
@@ -4527,8 +4473,6 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-
-  proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
 


### PR DESCRIPTION
## What

Replaces the `axios` dependency with the browser's native `fetch` API. Closes #316.

All axios usage was a handful of same-origin JSON requests — no interceptors, no custom instances — so `fetch` covers every case and the dependency can be dropped entirely.

## Changes

- **New helper** `app/api.ts`:
  - `getJSON<T>(url)` — GET + `res.ok` check + JSON parse
  - `postJSON(url, body?)` — POST with JSON body/headers (omitted when there's no body, e.g. logout) + `res.ok` check
  - `toError(res)` — clones the response and extracts `data.message` when present, falling back to `HTTP <status>`, preserving the server error messages the order flow shows users
- **Migrated 8 call sites** across 5 files:
  - `app/components/App.tsx` — `GET /api/products`
  - `app/reducers/users.ts` — `GET /api/users/`
  - `app/reducers/orders.ts` — `GET`/`POST /api/orders/`
  - `app/reducers/auth.ts` — whoami / login / signup / logout
- **Removed** `axios` from `package.json` and `pnpm-lock.yaml`.

## Reviewer notes

- The issue listed `GET /api/products` against `users.ts:33`, but that line actually calls `/api/users/`; the products GET lives in `App.tsx`. Both migrated correctly.
- `orders.ts` previously read `err?.response?.data?.message` (an axios-specific shape). Since `toError` now bakes the server message into `err.message`, the catch simplifies to `err?.message || <fallback>` with no behavior change.
- Added a `.catch` to the products fetch in `App.tsx`, which previously had none.

## Verification

- `tsc --noEmit` — passes
- `pnpm run lint` — 0 errors (only pre-existing warnings, none in changed files)
- `pnpm test` — 52 passed, 2 skipped
- `vite build` — succeeds (`✓ 70 modules transformed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)