### PR TITLE
chore: gitignore stale bundles and Claude Code local state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ node_modules/*
 # Vite build output
 dist/
 
+# Stale pre-Vite build artifacts (build now goes to dist/)
+public/bundle.js
+public/bundle.js.map
+
 # NPM errors
 npm-debug.log
 
@@ -18,3 +22,6 @@ package-lock.json
 
 # Local environment variables (use .env.example as template)
 .env
+
+# Claude Code local state
+.claude/


### PR DESCRIPTION
## What

- Delete orphaned pre-Vite build artifacts: `public/bundle.js` (3.3 MB) and `public/bundle.js.map` (3.5 MB).
- Add `.gitignore` rules for those files and for the `.claude/` local tooling directory.

## Why

The build now outputs to `dist/` (already gitignored via `vite.config`). The `public/bundle.js[.map]` files were leftover webpack-era output (last touched Jun 13) that nothing regenerates — they were showing up as untracked noise in `git status`. `.claude/` holds per-machine Claude Code session/memory state that should never be committed.

The bundle files were never tracked, so this PR only changes `.gitignore`; the ignore rules keep them from reappearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)